### PR TITLE
Fixing A Traitors Whisper 

### DIFF
--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -33,7 +33,10 @@ class AbilityTarget {
 
     canResolve(context) {
         const players = this.getChoosingPlayers(context);
-        return this.selector.canStartSelection(context, players) && this.subTargets.every(subTarget => subTarget.canResolve(context));
+        return this.ifAble || players.length > 0 && players.every(choosingPlayer => {
+            context.choosingPlayer = choosingPlayer;
+            return this.selector.hasEnoughTargets(context);
+        }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
     buildPlayerSelection(context) {

--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -33,10 +33,7 @@ class AbilityTarget {
 
     canResolve(context) {
         const players = this.getChoosingPlayers(context);
-        return this.ifAble || players.length > 0 && players.every(choosingPlayer => {
-            context.choosingPlayer = choosingPlayer;
-            return this.selector.hasEnoughTargets(context);
-        }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
+        return this.selector.canStartSelection(context, players) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
     buildPlayerSelection(context) {
@@ -139,7 +136,7 @@ class AbilityTarget {
                 return true;
             },
             onCancel: () => {
-                if(this.ifAble) {
+                if(this.selector.rejectAllowed(context)) {
                     result.reject();
                 } else {
                     result.cancel();

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -28,6 +28,7 @@ class BaseCardSelector {
         this.singleController = properties.singleController;
         this.isCardEffect = properties.isCardEffect;
         this.optional = !!properties.optional;
+        this.ifAble = !!properties.ifAble;
 
         if(!Array.isArray(properties.cardType)) {
             this.cardType = [properties.cardType];
@@ -73,6 +74,8 @@ class BaseCardSelector {
      * the currently selected cards
      * @param {integer} numPlayers
      * the number of players in the game
+     * @param {AbilityContext} context
+     * the context of the prompt, if able
      * @returns {boolean}
      */
     hasEnoughSelected(selectedCards) {
@@ -154,6 +157,31 @@ class BaseCardSelector {
         }
 
         return card.controller === selectedCards[0].controller;
+    }
+
+    /**
+     * Returns whether the selection meets the conditions to actually begin. This is
+     * primarily used by AbilityTarget to check whether it can resolve with the 
+     * available selection.
+     * @param {AbilityContext} context
+     * @param {Player[]} choosingPlayers
+     * @returns {boolean}
+     */
+    canStartSelection(context, choosingPlayers) {
+        return this.ifAble || choosingPlayers.length > 0 && choosingPlayers.every(choosingPlayer => {
+            context.choosingPlayer = choosingPlayer;
+            return this.hasEnoughTargets(context);
+        })
+    }
+
+    /**
+     * Returns whether this selection can be rejected when the choosing player decides 
+     * to cancel the selection entirely.
+     * @param {AbilityContext} context
+     * @returns {boolean}
+     */
+     rejectAllowed() {
+        return this.ifAble;
     }
 }
 

--- a/server/game/GameActions/RevealCard.js
+++ b/server/game/GameActions/RevealCard.js
@@ -11,6 +11,7 @@ class RevealCard extends GameAction {
 
     createEvent({ card }) {
         return this.event('onCardRevealed', { card }, () => {
+            card.game.addMessage('{0} has been revealed from {1}\'s {2}', card, card.controller, card.location);
             // TODO: There's a theoretical future UI where we prominently display
             // the revealed card, add a reveal effect and pause for all players
             // to acknowledge it, etc. But until then, this event does nothing.

--- a/server/game/cards/23-AHaH/ATraitorsWhisper.js
+++ b/server/game/cards/23-AHaH/ATraitorsWhisper.js
@@ -13,6 +13,7 @@ class ATraitorsWhisper extends DrawCard {
             },
             message: '{player} plays {source} to reveal 1 card in each players shadow area, if able',
             handler: context => {
+                context.target = context.target || []; // TODO: Discuss if this should be a built-in part of "ifAble AbilityTargets"
                 this.game.resolveGameAction(
                     GameActions.simultaneously(context => context.target.map(card => GameActions.revealCard({ card }))),
                     context

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -223,7 +223,7 @@ class SelectCardPrompt extends UiPrompt {
             return;
         }
 
-        if(this.selector.hasEnoughSelected(this.selectedCards, this.numPlayers)) {
+        if(this.selector.hasEnoughSelected(this.selectedCards, this.numPlayers, this.context)) {
             this.fireOnSelect();
         } else if(this.selectedCards.length === 0) {
             this.properties.onCancel(player);

--- a/test/server/gamesteps/selectcardprompt.spec.js
+++ b/test/server/gamesteps/selectcardprompt.spec.js
@@ -595,4 +595,5 @@ describe('the SelectCardPrompt', function() {
             });
         });
     });
+    // TODO: Add test for 'eachPlayer' selection
 });


### PR DESCRIPTION
Fixing this card by expanding on the logic for `EachPlayerCardSelector`, more specifically with the `ifAble` property.

Since this event is the first selection of its kind (being one player targeting a card for each player, **if able**), the logic for handling this simply hasn't been implemented/accounted for.

Using A Traitors Whisper as an example, previously if a player played the event (whilst there was a character in shadows), cancelling it, or not choosing targets when they are available, would be "valid"; this has been corrected to actually check if there are valid targets for the `choosingPlayer` before assuming that the ability is cancellable or before assuming they do not need to fulfil it in its entirety. This issue only occurred with `eachPlayer` mode.