### PR TITLE
Batch update to fix consistency & logic

### DIFF
--- a/server/game/GameActions/RevealCards.js
+++ b/server/game/GameActions/RevealCards.js
@@ -43,7 +43,6 @@ class RevealCards extends GameAction {
     }
 
     createEvent({ cards, player, whileRevealed, revealWithMessage = true, highlight = true, source, context }) {
-        context.revealing = cards;
         context.revealingPlayer = player;
         const allPlayers = context.game.getPlayers();
         const eventParams = {

--- a/server/game/cards/01-Core/GatesOfWinterfell.js
+++ b/server/game/cards/01-Core/GatesOfWinterfell.js
@@ -11,14 +11,12 @@ class GatesOfWinterfell extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => context.event.cards[0].isFaction('stark'),
                 message: '{player} {gameAction}',
-                gameAction: GameActions.ifCondition({
-                    condition: context => context.event.cards[0].isFaction('stark'),
-                    thenAction: GameActions.drawSpecific(context => ({
-                        player: context.player,
-                        cards: context.event.revealed
-                    }))
-                })
+                gameAction: GameActions.drawSpecific(context => ({
+                    player: context.player,
+                    cards: context.event.revealed
+                }))
             })
         });
     }

--- a/server/game/cards/05-LoCR/SummonedToCourt.js
+++ b/server/game/cards/05-LoCR/SummonedToCourt.js
@@ -19,8 +19,8 @@ class SummonedToCourt extends PlotCard {
                 this.game.resolveGameAction(
                     GameActions.revealCards(context => ({
                         cards: context.targets.getTargets()
-                    })).then(context => ({
-                        gameAction: GameActions.simultaneously(
+                    })).then({
+                        gameAction: GameActions.simultaneously(context =>
                             // Get the lowest cost characters that were revealed, but filter out any characters who are not still in reveal location (eg. Alla Tyrell or Sweetrobin)
                             this.getLowestCostCharacters(context.event.cards).filter(card => context.event.revealed.includes(card)).map(character => 
                                 GameActions.may({
@@ -34,15 +34,15 @@ class SummonedToCourt extends PlotCard {
                                 })
                             )
                         )
-                    })),
+                    }),
                     context
                 );
             }
         });
     }
 
-    getLowestCostCharacters(revealTargets) {
-        let characters = revealTargets.filter(card => card.getType() === 'character');
+    getLowestCostCharacters(cards) {
+        let characters = cards.filter(card => card.getType() === 'character');
         let minCost = Math.min(...characters.map(character => character.getPrintedCost()));
         return characters.filter(card => card.getPrintedCost() === minCost);
     }

--- a/server/game/cards/05-LoCR/SummonedToCourt.js
+++ b/server/game/cards/05-LoCR/SummonedToCourt.js
@@ -17,30 +17,32 @@ class SummonedToCourt extends PlotCard {
             },
             handler: context => {
                 this.game.resolveGameAction(
-                    GameActions.revealCards(context => ({ cards: context.targets.getTargets() }))
-                        .then(context => ({
-                            gameAction: GameActions.simultaneously(
-                                this.getLowestCostCharacters(context.revealed).map(character => 
-                                    GameActions.may({
-                                        player: character.controller,
-                                        title: `Put ${character.name} into play?`,
-                                        message: {
-                                            format: '{controller} {gameAction}',
-                                            args: { controller: () => character.controller }
-                                        },
-                                        gameAction: GameActions.putIntoPlay({ player: character.controller, card: character })
-                                    })
-                                )
+                    GameActions.revealCards(context => ({
+                        cards: context.targets.getTargets()
+                    })).then(context => ({
+                        gameAction: GameActions.simultaneously(
+                            // Get the lowest cost characters that were revealed, but filter out any characters who are not still in reveal location (eg. Alla Tyrell or Sweetrobin)
+                            this.getLowestCostCharacters(context.event.cards).filter(card => context.event.revealed.includes(card)).map(character => 
+                                GameActions.may({
+                                    player: character.controller,
+                                    title: `Put ${character.name} into play?`,
+                                    message: {
+                                        format: '{controller} {gameAction}',
+                                        args: { controller: () => character.controller }
+                                    },
+                                    gameAction: GameActions.putIntoPlay({ player: character.controller, card: character })
+                                })
                             )
-                        })),
+                        )
+                    })),
                     context
                 );
             }
         });
     }
 
-    getLowestCostCharacters(revealed) {
-        let characters = revealed.filter(card => card.getType() === 'character');
+    getLowestCostCharacters(revealTargets) {
+        let characters = revealTargets.filter(card => card.getType() === 'character');
         let minCost = Math.min(...characters.map(character => character.getPrintedCost()));
         return characters.filter(card => card.getPrintedCost() === minCost);
     }

--- a/server/game/cards/07-WotW/CalledIntoService.js
+++ b/server/game/cards/07-WotW/CalledIntoService.js
@@ -1,5 +1,6 @@
 const PlotCard = require('../../plotcard.js');
 const GameActions = require('../../GameActions');
+const { context } = require('raven');
 
 class CalledIntoService extends PlotCard {
     setupCardAbilities() {
@@ -11,7 +12,10 @@ class CalledIntoService extends PlotCard {
                 message: '{player} {gameAction}',
                 gameAction: GameActions.ifCondition({
                     condition: context => context.event.cards[0].getType() === 'character',
-                    thenAction: GameActions.simultaneously(context => context.event.revealed.map(card => GameActions.putIntoPlay({ card }))),
+                    thenAction: GameActions.ifCondition({
+                        condition: context => context.event.revealed.length > 0,
+                        thenAction: GameActions.putIntoPlay({ card: context.event.revealed[0] })
+                    }),
                     elseAction: GameActions.simultaneously(context => [
                         GameActions.drawSpecific(context => ({
                             player: context.player,

--- a/server/game/cards/07-WotW/CalledIntoService.js
+++ b/server/game/cards/07-WotW/CalledIntoService.js
@@ -1,6 +1,5 @@
 const PlotCard = require('../../plotcard.js');
 const GameActions = require('../../GameActions');
-const { context } = require('raven');
 
 class CalledIntoService extends PlotCard {
     setupCardAbilities() {
@@ -14,7 +13,7 @@ class CalledIntoService extends PlotCard {
                     condition: context => context.event.cards[0].getType() === 'character',
                     thenAction: GameActions.ifCondition({
                         condition: context => context.event.revealed.length > 0,
-                        thenAction: GameActions.putIntoPlay({ card: context.event.revealed[0] })
+                        thenAction: GameActions.putIntoPlay(context => ({ card: context.event.revealed[0] }))
                     }),
                     elseAction: GameActions.simultaneously(context => [
                         GameActions.drawSpecific(context => ({

--- a/server/game/cards/07-WotW/CalledIntoService.js
+++ b/server/game/cards/07-WotW/CalledIntoService.js
@@ -9,9 +9,9 @@ class CalledIntoService extends PlotCard {
                 player: context.player
             })).then({
                 message: '{player} {gameAction}',
-                gameAction:GameActions.ifCondition({
+                gameAction: GameActions.ifCondition({
                     condition: context => context.event.cards[0].getType() === 'character',
-                    thenAction: GameActions.putIntoPlay(context => ({ card: context.event.cards[0] })),
+                    thenAction: GameActions.simultaneously(context => context.event.revealed.map(card => GameActions.putIntoPlay({ card }))),
                     elseAction: GameActions.simultaneously(context => [
                         GameActions.drawSpecific(context => ({
                             player: context.player,

--- a/server/game/cards/08.2-JtO/MaegeMormont.js
+++ b/server/game/cards/08.2-JtO/MaegeMormont.js
@@ -11,14 +11,12 @@ class MaegeMormont extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => context.event.cards[0].isFaction('stark'),
                 message: '{player} {gameAction}',
-                gameAction: GameActions.ifCondition({
-                    condition: context => context.event.cards[0].isFaction('stark'),
-                    thenAction: GameActions.drawSpecific(context => ({
-                        player: context.player,
-                        cards: context.event.revealed
-                    }))
-                })
+                gameAction: GameActions.drawSpecific(context => ({
+                    player: context.player,
+                    cards: context.event.revealed
+                }))
             })
         });
     }

--- a/server/game/cards/09-HoT/CitadelNovice.js
+++ b/server/game/cards/09-HoT/CitadelNovice.js
@@ -16,14 +16,12 @@ class CitadelNovice extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => isAttachmentOrMaester(context.event.cards[0]),
                 message: '{player} {gameAction}',
-                gameAction: GameActions.ifCondition({
-                    condition: context => isAttachmentOrMaester(context.event.cards[0]),
-                    thenAction: GameActions.drawSpecific(context => ({
-                        player: context.player,
-                        cards: context.event.revealed
-                    }))
-                })
+                gameAction: GameActions.drawSpecific(context => ({
+                    player: context.player,
+                    cards: context.event.revealed
+                }))
             })
         });
     }

--- a/server/game/cards/11.3-SoKL/WhiteHarbor.js
+++ b/server/game/cards/11.3-SoKL/WhiteHarbor.js
@@ -11,7 +11,6 @@ class WhiteHarbor extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player,
                 amount: 2,
-                //TODO: When a SelectCards GameAction is implemented, update the below
                 whileRevealed: GameActions.genericHandler(context => {
                     if(context.revealed.length > 0) {
                         this.game.promptForSelect(context.event.challenge.loser, {

--- a/server/game/cards/11.4-MoD/SerMarkMullendore.js
+++ b/server/game/cards/11.4-MoD/SerMarkMullendore.js
@@ -1,3 +1,4 @@
+const { context } = require('raven');
 const DrawCard = require('../../drawcard');
 const GameActions = require('../../GameActions');
 
@@ -11,13 +12,14 @@ class SerMarkMullendore extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => context.event.revealed.length > 0,
                 gameAction: GameActions.may({
-                    title: context => `Put ${context.event.cards[0].name} into play?`,
+                    title: context => `Put ${context.event.revealed[0].name} into play?`,
                     message: '{player} {gameAction}',
                     gameAction: GameActions.simultaneously([
                         GameActions.putIntoPlay(context => ({
                             player: context.player,
-                            card: context.event.cards[0]
+                            card: context.event.revealed[0]
                         })),
                         GameActions.returnCardToDeck(context => ({
                             allowSave: false,

--- a/server/game/cards/11.4-MoD/SerMarkMullendore.js
+++ b/server/game/cards/11.4-MoD/SerMarkMullendore.js
@@ -1,4 +1,3 @@
-const { context } = require('raven');
 const DrawCard = require('../../drawcard');
 const GameActions = require('../../GameActions');
 

--- a/server/game/cards/11.6-DitD/NightfortBuilder.js
+++ b/server/game/cards/11.6-DitD/NightfortBuilder.js
@@ -11,17 +11,15 @@ class NightfortBuilder extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => context.event.cards[0].isMatch({
+                    faction: 'thenightswatch',
+                    type: ['attachment', 'location']
+                }),
                 message: '{player} {gameAction}',
-                gameAction: GameActions.ifCondition({
-                    condition: context => context.event.cards[0].isMatch({
-                        faction: 'thenightswatch',
-                        type: ['attachment', 'location']
-                    }),
-                    thenAction: GameActions.drawSpecific(context => ({
-                        player: context.player,
-                        cards: context.event.revealed
-                    }))
-                })
+                gameAction: GameActions.drawSpecific(context => ({
+                    player: context.player,
+                    cards: context.event.revealed
+                }))
             })
         });
     }

--- a/server/game/cards/13.3-PoS/JonConnington.js
+++ b/server/game/cards/13.3-PoS/JonConnington.js
@@ -12,23 +12,22 @@ class JonConnington extends DrawCard {
             },
             message: '{player} uses {source} to reveal a card from shadows',
             handler: context => {
-                const gameAction = GameActions.revealCards(context => ({
-                    player: context.player,
-                    cards: [context.target]
-                })).then({
-                    message: '{player} {gameAction}',
-                    gameAction: GameActions.ifCondition({
+                this.game.resolveGameAction(
+                    GameActions.revealCards(context => ({
+                        player: context.player,
+                        cards: [context.target]
+                    })).then({
                         condition: context => context.event.cards[0].isMatch({
                             printedCostOrLower: 4,
                             not: { type: 'event' }
-                        }),
-                        thenAction: GameActions.putIntoPlay(context => ({
-                            card: context.event.cards[0]
+                        }) && context.event.revealed.length > 0,
+                        message: '{player} {gameAction}',
+                        gameAction: GameActions.putIntoPlay(context => ({
+                            card: context.event.revealed[0]
                         }))
-                    })
-                });
-
-                this.game.resolveGameAction(gameAction, context);
+                    }),
+                    context
+                );
             }
         });
     }

--- a/server/game/cards/15-DotE/DothrakiHandmaiden.js
+++ b/server/game/cards/15-DotE/DothrakiHandmaiden.js
@@ -25,12 +25,13 @@ class DothrakiHandmaiden extends DrawCard {
                         player: context.player,
                         cards: [context.target]
                     })).then({
+                        condition: context => context.event.revealed.length > 0,
                         handler: context => {
-                            context.player.attach(context.player, context.event.cards[0], this, 'play', true);
+                            context.player.attach(context.player, context.event.revealed[0], this, 'play', true);
                             this.lastingEffect(() => ({
-                                condition: () => context.event.cards[0].parent === context.source,
+                                condition: () => context.event.revealed[0].parent === context.source,
                                 targetLocation: 'any',
-                                match: context.event.cards[0],
+                                match: context.event.revealed[0],
                                 effect: ability.effects.setCardType('attachment')
                             }));
                         }

--- a/server/game/cards/15-DotE/Pentos.js
+++ b/server/game/cards/15-DotE/Pentos.js
@@ -23,9 +23,9 @@ class Pentos extends DrawCard {
                 gameAction: GameActions.putIntoPlay(context => ({
                     card: context.event.revealed[0]
                 })).then({
-                    message: 'Then {player} draws 1 card',
-                    gameAction: GameActions.drawCards(thenContext => ({
-                        player: thenContext.player,
+                    message: 'Then, {player} draws 1 card',
+                    gameAction: GameActions.drawCards(context => ({
+                        player: context.player,
                         amount: 1
                     }))
                 })

--- a/server/game/cards/15-DotE/Pentos.js
+++ b/server/game/cards/15-DotE/Pentos.js
@@ -19,8 +19,9 @@ class Pentos extends DrawCard {
                 player: context.player,
                 cards: [context.event.card]
             })).then({
+                condition: context => context.event.revealed.length > 0,
                 gameAction: GameActions.putIntoPlay(context => ({
-                    card: context.event.cards[0]
+                    card: context.event.revealed[0]
                 })).then({
                     message: 'Then {player} draws 1 card',
                     gameAction: GameActions.drawCards(thenContext => ({

--- a/server/game/cards/18-FH/HaldonHalfmaester.js
+++ b/server/game/cards/18-FH/HaldonHalfmaester.js
@@ -1,7 +1,6 @@
 const DrawCard = require('../../drawcard.js');
 const {Tokens} = require('../../Constants');
 const GameActions = require('../../GameActions');
-const { context } = require('raven');
 
 class HaldonHalfmaester extends DrawCard {
     setupCardAbilities() {

--- a/server/game/cards/18-FH/HaldonHalfmaester.js
+++ b/server/game/cards/18-FH/HaldonHalfmaester.js
@@ -1,6 +1,7 @@
 const DrawCard = require('../../drawcard.js');
 const {Tokens} = require('../../Constants');
 const GameActions = require('../../GameActions');
+const { context } = require('raven');
 
 class HaldonHalfmaester extends DrawCard {
     setupCardAbilities() {
@@ -12,11 +13,11 @@ class HaldonHalfmaester extends DrawCard {
             gameAction: GameActions.revealTopCards(context => ({
                 player: context.player
             })).then({
+                condition: context => context.event.revealed.length > 0,
                 handler: context => {
-                    let topCard = context.event.revealed.length > 0 ? context.event.revealed[0] : null;
-
+                    let topCard = context.event.revealed[0];
                     //place 1 gold on card of the same type
-                    if(topCard && ['character', 'location', 'attachment'].includes(topCard.getType()) &&
+                    if(['character', 'location', 'attachment'].includes(topCard.getType()) &&
                         this.game.anyCardsInPlay(card => card.getType() === topCard.getType())) {
                         this.game.promptForSelect(context.player, {
                             activePromptTitle: 'Select card to gain 1 gold',

--- a/server/game/cards/19-JS/RandyllTarly.js
+++ b/server/game/cards/19-JS/RandyllTarly.js
@@ -28,21 +28,17 @@ class RandyllTarly extends DrawCard {
                             player: context.player,
                             revealWithMessage: false
                         })).then({
+                            condition: context => context.event.cards[0].isMatch({ type: 'location' }) && context.event.revealed.length > 0,
+                            message: '{player} {gameAction}',
                             gameAction: GameActions.ifCondition({
-                                condition: context => context.event.revealed.length > 0 && context.event.revealed[0].isMatch({ type: 'location' }),
-                                thenAction: {
-                                    message: '{player} {gameAction}',
-                                    gameAction: GameActions.ifCondition({
-                                        condition: context => context.event.revealed[0].isMatch({ trait: 'The Reach' }),
-                                        thenAction: GameActions.putIntoPlay(context => ({
-                                            card: context.event.revealed[0]
-                                        })),
-                                        elseAction: GameActions.drawSpecific(context => ({
-                                            player: context.player,
-                                            cards: context.event.revealed
-                                        }))
-                                    })
-                                }
+                                condition: context => context.event.cards[0].isMatch({ trait: 'The Reach' }),
+                                thenAction: GameActions.putIntoPlay(context => ({
+                                    card: context.event.revealed[0]
+                                })),
+                                elseAction: GameActions.drawSpecific(context => ({
+                                    player: context.player,
+                                    cards: context.event.revealed
+                                }))
                             })
                         })
                     }

--- a/server/game/cards/20-HMW/TheHigherMysteries.js
+++ b/server/game/cards/20-HMW/TheHigherMysteries.js
@@ -12,10 +12,7 @@ class TheHigherMysteries extends DrawCard {
                 player: context.player
             })).then({
                 condition: context => context.event.revealed.length > 0,
-                message: {
-                    format: '{player} puts {topCard} into play',
-                    args: { topCard: context => context.event.revealed[0] }
-                },
+                message: '{player} {gameAction}',
                 gameAction: GameActions.putIntoPlay(context => ({
                     player: context.player,
                     card: context.event.revealed[0]

--- a/server/game/cards/22-BtB/Highgarden.js
+++ b/server/game/cards/22-BtB/Highgarden.js
@@ -31,11 +31,11 @@ class Highgarden extends DrawCard {
                             numCards: preThenContext.target.length,
                             gameAction: 'increaseStrength'
                         },
-                        handler: thenContext => {
+                        handler: context => {
                             this.groups = {};
-                            this.remainingCards = thenContext.target;
-                            this.remainingStr = thenContext.parentContext.target.length * 2;
-                            this.game.queueSimpleStep(() => this.calculateNextCharacter(thenContext.player));
+                            this.remainingCards = context.target;
+                            this.remainingStr = context.event.cards.length * 2;
+                            this.game.queueSimpleStep(() => this.calculateNextCharacter(context.player));
 
                             this.game.queueSimpleStep(() => {
                                 let strMessages = [];
@@ -52,7 +52,7 @@ class Highgarden extends DrawCard {
                                     strMessages.push(Message.fragment('{characters} +{strength} STR', { characters, strength }));
                                 }
 
-                                this.game.addMessage('{0} gives {1} until the end of the phase', thenContext.player, strMessages);
+                                this.game.addMessage('{0} gives {1} until the end of the phase', context.player, strMessages);
 
                                 return true;
                             });

--- a/server/game/cards/23-AHaH/AnyaWaynwood.js
+++ b/server/game/cards/23-AHaH/AnyaWaynwood.js
@@ -15,7 +15,6 @@ class AnyaWaynwood extends DrawCard {
             condition: () => this.game.isDuringChallenge(),
             limit: ability.limit.perPhase(1),
             target: {
-                title: 'Select a character',
                 cardCondition: {
                     location: 'play area',
                     type: 'character',

--- a/server/game/cards/23-AHaH/CrastersKeepMutineer.js
+++ b/server/game/cards/23-AHaH/CrastersKeepMutineer.js
@@ -8,7 +8,7 @@ class CrastersKeepMutineer extends DrawCard {
                 onCardEntersPlay: event => event.card === this
             },
             target: {
-                title: 'Select a duplicate',
+                activePromptTitle: 'Select a duplicate',
                 cardCondition: card => card.location === 'duplicate' && card.parent.getType() === 'character'
             },
             message: {

--- a/server/game/cards/23-AHaH/DefensiveDebris.js
+++ b/server/game/cards/23-AHaH/DefensiveDebris.js
@@ -9,7 +9,7 @@ class DefensiveDebris extends DrawCard {
             title: 'Discard gold to choose a discarded card',
             cost: ability.costs.discardGold(),
             target: {
-                title: 'Select a card',
+                activePromptTitle: 'Select a card',
                 cardCondition: { location: 'discard pile', controller: 'opponent' }
             },
             phase: 'challenge',

--- a/server/game/cards/23-AHaH/Littlefinger.js
+++ b/server/game/cards/23-AHaH/Littlefinger.js
@@ -26,13 +26,13 @@ class Littlefinger extends DrawCard {
                         condition: context => this.noOpponentRevealedSameCardtype(context.player, context.event.cards),
                         target: {
                             activePromptTitle: 'Select a card',
-                            cardCondition: card => card.getPower() > 0,
+                            cardCondition: card => card.getPower() > 0 && card !== this,
                             cardType: ['attachment', 'character', 'faction', 'location']
                         },
                         message: '{player} moves 1 power from {target} to {source}',
                         handler: context => {
                             this.game.resolveGameAction(
-                                GameActions.movePower({ from: card, to: this, amount: 1 }),
+                                GameActions.movePower({ from: context.target, to: this, amount: 1 }),
                                 context
                             );
                         }

--- a/server/game/cards/23-AHaH/Littlefinger.js
+++ b/server/game/cards/23-AHaH/Littlefinger.js
@@ -23,20 +23,19 @@ class Littlefinger extends DrawCard {
                     GameActions.revealCards(context => ({
                         cards: context.targets.getTargets()
                     })).then({
-                        gameAction: GameActions.ifCondition({
-                            condition: context => this.noOpponentRevealedSameCardtype(context.player, context.parentContext.revealed),
-                            thenAction: GameActions.genericHandler(context => {
-                                this.game.promptForSelect(context.player, {
-                                    activePromptTitle: 'Select a card',
-                                    source: this,
-                                    cardCondition: card => card.getPower() > 0,
-                                    cardType: ['attachment', 'character', 'faction', 'location'],
-                                    gameAction: 'movePower',
-                                    onSelect: (player, card) => this.onSelectCard(player, card),
-                                    onCancel: (player) => this.onSelectCard(player, null)
-                                });
-                            })
-                        })
+                        condition: context => this.noOpponentRevealedSameCardtype(context.player, context.event.cards),
+                        target: {
+                            activePromptTitle: 'Select a card',
+                            cardCondition: card => card.getPower() > 0,
+                            cardType: ['attachment', 'character', 'faction', 'location']
+                        },
+                        message: '{player} moves 1 power from {target} to {source}',
+                        handler: context => {
+                            this.game.resolveGameAction(
+                                GameActions.movePower({ from: card, to: this, amount: 1 }),
+                                context
+                            );
+                        }
                     }),
                     context
                 );
@@ -44,25 +43,8 @@ class Littlefinger extends DrawCard {
         });
     }
 
-    onSelectCard(player, card) {
-        if(card === null) {
-            this.game.addAlert('danger', '{0} does not choose any card for {1}', player, this);
-            return true;
-        }
-
-        this.game.resolveGameAction(
-            GameActions.movePower({
-                from: card,
-                to: this,
-                amount: 1
-            })
-        );
-        this.game.addMessage('{0} moves 1 power from {1} to {2}', player, card, this);
-        return true;
-    }
-
-    noOpponentRevealedSameCardtype(player, revealed) {
-        return revealed.every(card1 => card1.controller === player || revealed.every(card2 => card1 === card2 || card1.getType() !== card2.getType()));
+    noOpponentRevealedSameCardtype(player, cards) {
+        return cards.every(card1 => card1.controller === player || cards.every(card2 => card1 === card2 || card1.getType() !== card2.getType()));
     }
 }
 

--- a/server/game/cards/23-AHaH/Mord.js
+++ b/server/game/cards/23-AHaH/Mord.js
@@ -7,6 +7,7 @@ class Mord extends DrawCard {
             title: 'Kneel to blank card',
             cost: ability.costs.kneelSelf(),
             target: {
+                activePromptTitle: 'Select a card',
                 cardCondition: card => card.isMatch({ location: 'play area', type: 'character' }) || card.isMatch({ location: 'shadows' })
             },
             message: {

--- a/server/game/cards/23-AHaH/TheBalerion.js
+++ b/server/game/cards/23-AHaH/TheBalerion.js
@@ -16,7 +16,6 @@ class TheBalerion extends DrawCard {
                 ability.costs.shuffleSelfIntoDeck()
             ],
             target: {
-                title: 'Select a character',
                 cardCondition: { faction: 'targaryen', type: 'character', location: 'play area' }
             },
             phase: 'challenge',


### PR DESCRIPTION
Fixing the consistency of some cards, especially when 1 revealed card is involved.

For `RevealCards` event...
`event.cards` will always populate what was being **revealed**, for any comparison abilities (eg. Summoned to Court, or Littlefinger (AHaH))
`event.revealed` will always populate what was successfully **revealed** (eg. not moved as an interrupt of being revealed), for any abilities which interact with the revealed card after reveal (eg. Randyll Tarly (JS))