### PR TITLE
Remove redundant condition LordProtectorsRetainer.js

### DIFF
--- a/server/game/cards/23-AHaH/LordProtectorsRetainer.js
+++ b/server/game/cards/23-AHaH/LordProtectorsRetainer.js
@@ -7,11 +7,11 @@ class LordProtectorsRetainer extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCardAbilityInitiated: event =>    event.targets.hasSingleTarget() &&
-                                                    event.targets.anySelection(selection => (
-                                                        selection.value.controller === this.controller &&
-                                                        selection.value.isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
-                                                    ))
+                onCardAbilityInitiated: event => event.targets.hasSingleTarget() &&
+                                                event.targets.anySelection(selection => (
+                                                    selection.value.controller === this.controller &&
+                                                    selection.value.isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
+                                                ))
             },
             max: ability.limit.perPhase(1),
             gameAction: GameActions.cancelEffects(context => ({ event: context.event }))

--- a/server/game/cards/23-AHaH/LordProtectorsRetainer.js
+++ b/server/game/cards/23-AHaH/LordProtectorsRetainer.js
@@ -7,12 +7,16 @@ class LordProtectorsRetainer extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCardAbilityInitiated: event => event.targets.hasSingleTarget() &&
-                                                event.targets.anySelection(selection => (
-                                                    selection.value.controller === this.controller &&
-                                                    selection.value.isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
-                                                ))
+                onCardAbilityInitiated: event => event.ability.targets.some(target => target.type === 'choose') &&
+                                                event.targets.length === 1 && 
+                                                event.targets[0].controller === this.controller &&
+                                                event.targets[0].isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
             },
+            message: {
+                format: '{player} returns {source} to their hand to cancel {event}',
+                args: { event: context => context.event.source }
+            },
+            cost: ability.costs.returnSelfToHand(),
             max: ability.limit.perPhase(1),
             gameAction: GameActions.cancelEffects(context => ({ event: context.event }))
         });

--- a/server/game/cards/23-AHaH/LordProtectorsRetainer.js
+++ b/server/game/cards/23-AHaH/LordProtectorsRetainer.js
@@ -7,13 +7,11 @@ class LordProtectorsRetainer extends DrawCard {
         this.interrupt({
             canCancel: true,
             when: {
-                onCardAbilityInitiated: event => event.ability.targets.some(target => target.type === 'choose') &&
-                                                event.targets.hasSingleTarget() &&
-                                                event.targets.anySelection(selection => (
-                                                    selection.choosingPlayer !== this.controller &&
-                                                    selection.value.controller === this.controller &&
-                                                    selection.value.isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
-                                                ))
+                onCardAbilityInitiated: event =>    event.targets.hasSingleTarget() &&
+                                                    event.targets.anySelection(selection => (
+                                                        selection.value.controller === this.controller &&
+                                                        selection.value.isMatch({ trait: ['Lord', 'Lady'], type: 'character' })
+                                                    ))
             },
             max: ability.limit.perPhase(1),
             gameAction: GameActions.cancelEffects(context => ({ event: context.event }))


### PR DESCRIPTION
This could fix the problem hopefully, there was a redundant condition with syntax error (`type` instead of `targetingType`).

Also removed condition for the choosing player being opponent, as that is not in the text of the card.