### PR TITLE
Implementing a more robust 'contributing STR' system

### DIFF
--- a/server/game/ChallengeContributions.js
+++ b/server/game/ChallengeContributions.js
@@ -1,0 +1,107 @@
+class ChallengeContributions {
+    constructor() {
+        this.contributions = [];
+    }
+
+    addParticipants(participants, towardsPlayer) {
+        this.contributions = this.contributions.concat(participants.map(card => new CharacterStrengthContribution(towardsPlayer, card, true)));
+        this.refresh(participants);
+    }
+
+    removeParticipants(participants) {
+        this.contributions = this.contributions.filter(c => !(c instanceof CharacterStrengthContribution && c.isParticipation && participants.includes(c.card)));
+        this.refresh(participants);
+    }
+
+    addContribution(contribution) {
+        this.contributions.push(contribution);
+        this.refresh([contribution.card]);
+    }
+
+    removeContribution(contribution) {
+        let index = this.contributions.indexOf(contribution);
+        if(index >= 0) {
+            this.contributions.splice(index, 1);
+        }
+        this.refresh([contribution.card]);
+    }
+
+    clear(cards) {
+        cards = cards || this.contributions.map(c => c.card);
+        this.contributions = this.contributions.filter(c => !cards.includes(c.card));
+        this.refresh(cards);
+    }
+
+    refresh(cards) {
+        cards = cards || this.contributions.map(c => c.card);
+        for(let card of cards) {
+            card.isContributing = this.isContributing(card);
+
+            // Updating character contributions for that card to ensure only latest is applied
+            let characterContributions = this.contributions.filter(c => c instanceof CharacterStrengthContribution && c.card === card).reverse();
+            for(let index in characterContributions) {
+                characterContributions[index].isLatest = (index === '0');
+            }
+        }
+    }
+
+    isContributing(card) {
+        return this.contributions.some(c => c.card === card);
+    }
+
+    getTotalFor(player) {
+        return this.contributions.filter(c => c.towardsPlayer === player).reduce((sum, c) => {
+            if(!c.isActive()) {
+                return sum;
+            }
+
+            return sum + c.getStrength();
+        }, 0);
+    }
+}
+
+class ValueContribution {
+    constructor(towardsPlayer, card, value) {
+        this.towardsPlayer = towardsPlayer;
+        this.card = card;
+        this.value = value;
+
+        this.card.isContributing = true;
+    }
+
+    isActive() {
+        return true;
+    }
+
+    getStrength() {
+        return this.value;
+    }
+}
+
+class CharacterStrengthContribution {
+    constructor(towardsPlayer, card, isParticipation = false) {
+        this.towardsPlayer = towardsPlayer;
+        this.card = card;
+        this.isParticipation = isParticipation;
+        this.isLatest = true;
+
+        this.card.isContributing = true;
+    }
+
+    isActive() {
+        if(this.isLatest && !(this.card.challengeOptions && this.card.challengeOptions.contains('doesNotContributeStrength'))) {
+            return true;
+        }
+        return false;
+    }
+
+    getStrength() {
+        return this.card.getStrength();
+    }
+}
+
+module.exports = {
+    ChallengeContributions: ChallengeContributions,
+    ValueContribution: ValueContribution,
+    CharacterStrengthContribution: CharacterStrengthContribution
+};

--- a/server/game/ChallengeMatcher.js
+++ b/server/game/ChallengeMatcher.js
@@ -18,7 +18,8 @@ class ChallengeMatcher {
             Matcher.containsValue(matchers.unopposed, challenge.isUnopposed()) &&
             Matcher.anyValue(matchers.by5, value => (challenge.strengthDifference >= 5) === value) &&
             Matcher.anyValue(matchers.match, func => func(challenge)) &&
-            Matcher.anyValue(matchers.not, notProperties => !ChallengeMatcher.isMatch(challenge, notProperties))
+            Matcher.anyValue(matchers.not, notProperties => !ChallengeMatcher.isMatch(challenge, notProperties)) &&
+            Matcher.anyValue(matchers.or, orProperties => ChallengeMatcher.isMatch(challenge, orProperties))
         );
     }
 

--- a/server/game/cards/01-Core/TheRedKeep.js
+++ b/server/game/cards/01-Core/TheRedKeep.js
@@ -13,7 +13,7 @@ class TheRedKeep extends DrawCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller) &&
                 this.controller.canDraw(),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(2)
+            effect: ability.effects.contributeChallengeStrength(this, 2)
         });
         this.interrupt({
             when: {

--- a/server/game/cards/01-Core/TheRedKeep.js
+++ b/server/game/cards/01-Core/TheRedKeep.js
@@ -13,7 +13,7 @@ class TheRedKeep extends DrawCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller) &&
                 this.controller.canDraw(),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(this, 2)
+            effect: ability.effects.contributeStrength(this, 2)
         });
         this.interrupt({
             when: {

--- a/server/game/cards/04.4-TIMC/TheHauntedForest.js
+++ b/server/game/cards/04.4-TIMC/TheHauntedForest.js
@@ -8,7 +8,7 @@ class TheHauntedForest extends DrawCard {
                 this.game.isDuringChallenge({ defendingPlayer: this.controller })
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(this, 1)
+            effect: ability.effects.contributeStrength(this, 1)
         });
         this.forcedReaction({
             when: {

--- a/server/game/cards/04.4-TIMC/TheHauntedForest.js
+++ b/server/game/cards/04.4-TIMC/TheHauntedForest.js
@@ -8,7 +8,7 @@ class TheHauntedForest extends DrawCard {
                 this.game.isDuringChallenge({ defendingPlayer: this.controller })
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(1)
+            effect: ability.effects.contributeChallengeStrength(this, 1)
         });
         this.forcedReaction({
             when: {

--- a/server/game/cards/23-AHaH/AnyaWaynwood.js
+++ b/server/game/cards/23-AHaH/AnyaWaynwood.js
@@ -22,7 +22,7 @@ class AnyaWaynwood extends DrawCard {
                 }
             },
             message: {
-                format: '{player} uses {source} and kneels {kneel} to have {target} contribute its STR (currently {STR}) to {player}\'s side this challenge',
+                format: '{player} uses {source} and kneels {kneel} to have {target} contribute its STR to {player}\'s side this challenge',
                 args: {
                     kneel: context => context.costs.kneel,
                     STR: context => context.target.getStrength()

--- a/server/game/cards/23-AHaH/AnyaWaynwood.js
+++ b/server/game/cards/23-AHaH/AnyaWaynwood.js
@@ -21,7 +21,10 @@ class AnyaWaynwood extends DrawCard {
                     condition: (card, context) => !context.costs.kneel || card.getPrintedCost() <= context.costs.kneel.getPrintedCost()
                 }
             },
-            message: '{player} uses {source} and kneels {costs.kneel} to have {target} contribute its STR to {player}\'s side this challenge',
+            message: {
+                format: '{player} uses {source} and kneels {costs.kneel} to have {target} contribute its STR (currently {str}) to {player}\'s side of the challenge',
+                args: { str: context => context.target.getStrength() }
+            },
             handler: context => {
                 this.untilEndOfChallenge(ability => ({
                     targetController: 'current',

--- a/server/game/cards/23-AHaH/AnyaWaynwood.js
+++ b/server/game/cards/23-AHaH/AnyaWaynwood.js
@@ -21,18 +21,11 @@ class AnyaWaynwood extends DrawCard {
                     condition: (card, context) => !context.costs.kneel || card.getPrintedCost() <= context.costs.kneel.getPrintedCost()
                 }
             },
-            message: {
-                format: '{player} uses {source} and kneels {kneel} to have {target} contribute its STR to {player}\'s side this challenge',
-                args: {
-                    kneel: context => context.costs.kneel,
-                    STR: context => context.target.getStrength()
-                }
-            },
+            message: '{player} uses {source} and kneels {costs.kneel} to have {target} contribute its STR to {player}\'s side this challenge',
             handler: context => {
                 this.untilEndOfChallenge(ability => ({
-                    condition: () => true,
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(context.target)
+                    effect: ability.effects.contributeCharacterStrength(context.target)
                 }));
             }
         });

--- a/server/game/cards/23-AHaH/AnyaWaynwood.js
+++ b/server/game/cards/23-AHaH/AnyaWaynwood.js
@@ -30,10 +30,9 @@ class AnyaWaynwood extends DrawCard {
             },
             handler: context => {
                 this.untilEndOfChallenge(ability => ({
-                    // Force the effect to recalculate mid-challenge in case the character STR changes
                     condition: () => true,
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(() => context.target.getStrength())
+                    effect: ability.effects.contributeChallengeStrength(context.target)
                 }));
             }
         });

--- a/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
+++ b/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
@@ -18,8 +18,11 @@ class LordProtectorOfTheVale extends DrawCard {
                 && this.game.currentChallenge.challengeType === 'power'
                 && this.controller.anyCardsInPlay({ trait: 'House Arryn', type: 'character', participating: true }),
             message: {
-                format: '{player} kneels {source} to have {parent} contribute its STR to {player}\'s side this challenge',
-                args: { parent: () => this.parent }
+                format: '{player} kneels {source} to have {parent} contribute its STR (currently {str}) to {player}\'s side of the challenge',
+                args: {
+                    parent: () => this.parent,
+                    str: () => this.parent.getStrength()
+                }
             },
             gameAction: GameActions.genericHandler(() => {
                 this.untilEndOfChallenge(ability => ({

--- a/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
+++ b/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
@@ -1,4 +1,5 @@
 const DrawCard = require('../../drawcard.js');
+const GameActions = require('../../GameActions');
 
 class LordProtectorOfTheVale extends DrawCard {
     setupCardAbilities(ability) {
@@ -18,18 +19,14 @@ class LordProtectorOfTheVale extends DrawCard {
                 && this.controller.anyCardsInPlay({ trait: 'House Arryn', type: 'character', participating: true }),
             message: {
                 format: '{player} kneels {source} to have {parent} contribute its STR to {player}\'s side this challenge',
-                args: { 
-                    parent: () => this.parent,
-                    STR: () => this.parent.getStrength()
-                }
+                args: { parent: () => this.parent }
             },
-            handler: () => {
+            gameAction: GameActions.genericHandler(() => {
                 this.untilEndOfChallenge(ability => ({
-                    condition: () => true,
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(this.parent)
+                    effect: ability.effects.contributeCharacterStrength(this.parent)
                 }));
-            }
+            })
         });
     }
 }

--- a/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
+++ b/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
@@ -17,7 +17,7 @@ class LordProtectorOfTheVale extends DrawCard {
                 && this.game.currentChallenge.challengeType === 'power'
                 && this.controller.anyCardsInPlay({ trait: 'House Arryn', type: 'character', participating: true }),
             message: {
-                format: '{player} kneels {source} to have {parent} contribute its STR (currently {STR}) to {player}\'s side this challenge',
+                format: '{player} kneels {source} to have {parent} contribute its STR to {player}\'s side this challenge',
                 args: { 
                     parent: () => this.parent,
                     STR: () => this.parent.getStrength()

--- a/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
+++ b/server/game/cards/23-AHaH/LordProtectorOfTheVale.js
@@ -15,8 +15,7 @@ class LordProtectorOfTheVale extends DrawCard {
             cost: ability.costs.kneelSelf(),
             condition: () => this.game.isDuringChallenge()
                 && this.game.currentChallenge.challengeType === 'power'
-                && this.controller.anyCardsInPlay({ trait: 'House Arryn', type: 'character', participating: true })
-                && !this.isParticipating(), // TODO: Remove this once contributeSTR properly prevents a participating character also contributing (adding STR twice)
+                && this.controller.anyCardsInPlay({ trait: 'House Arryn', type: 'character', participating: true }),
             message: {
                 format: '{player} kneels {source} to have {parent} contribute its STR (currently {STR}) to {player}\'s side this challenge',
                 args: { 
@@ -26,10 +25,9 @@ class LordProtectorOfTheVale extends DrawCard {
             },
             handler: () => {
                 this.untilEndOfChallenge(ability => ({
-                    // Force the effect to recalculate mid-challenge in case the character STR changes
                     condition: () => true,
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(() => this.parent.getStrength())
+                    effect: ability.effects.contributeChallengeStrength(this.parent)
                 }));
             }
         });

--- a/server/game/cards/23-AHaH/TheEyrie.js
+++ b/server/game/cards/23-AHaH/TheEyrie.js
@@ -25,7 +25,6 @@ class TheEyrie extends DrawCard {
             },
             gameAction: GameActions.genericHandler(() => {
                 this.untilEndOfChallenge(ability => ({
-                    condition: () => true,
                     targetController: 'current',
                     effect: ability.effects.contributeChallengeStrength(this, this.calculateAmount())
                 }));

--- a/server/game/cards/23-AHaH/TheEyrie.js
+++ b/server/game/cards/23-AHaH/TheEyrie.js
@@ -26,7 +26,7 @@ class TheEyrie extends DrawCard {
             gameAction: GameActions.genericHandler(() => {
                 this.untilEndOfChallenge(ability => ({
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(this, this.calculateAmount())
+                    effect: ability.effects.contributeStrength(this, this.calculateAmount())
                 }));
             })
         });

--- a/server/game/cards/23-AHaH/TheEyrie.js
+++ b/server/game/cards/23-AHaH/TheEyrie.js
@@ -27,7 +27,7 @@ class TheEyrie extends DrawCard {
                 this.untilEndOfChallenge(ability => ({
                     condition: () => true,
                     targetController: 'current',
-                    effect: ability.effects.contributeChallengeStrength(this.calculateAmount())
+                    effect: ability.effects.contributeChallengeStrength(this, this.calculateAmount())
                 }));
             }
         });

--- a/server/game/cards/titles/HandOfTheKing.js
+++ b/server/game/cards/titles/HandOfTheKing.js
@@ -18,7 +18,7 @@ class HandOfTheKing extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(1)
+            effect: ability.effects.contributeChallengeStrength(this, 1)
         });
     }
 

--- a/server/game/cards/titles/HandOfTheKing.js
+++ b/server/game/cards/titles/HandOfTheKing.js
@@ -18,7 +18,7 @@ class HandOfTheKing extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(this, 1)
+            effect: ability.effects.contributeStrength(this, 1)
         });
     }
 

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -21,7 +21,7 @@ class MasterOfShips extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(this, 1)
+            effect: ability.effects.contributeStrength(this, 1)
         });
     }
 }

--- a/server/game/cards/titles/MasterOfShips.js
+++ b/server/game/cards/titles/MasterOfShips.js
@@ -21,7 +21,7 @@ class MasterOfShips extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(1)
+            effect: ability.effects.contributeChallengeStrength(this, 1)
         });
     }
 }

--- a/server/game/cards/titles/MasterOfWhispers.js
+++ b/server/game/cards/titles/MasterOfWhispers.js
@@ -15,7 +15,7 @@ class MasterOfWhispers extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(1)
+            effect: ability.effects.contributeChallengeStrength(this, 1)
         });
     }
 }

--- a/server/game/cards/titles/MasterOfWhispers.js
+++ b/server/game/cards/titles/MasterOfWhispers.js
@@ -15,7 +15,7 @@ class MasterOfWhispers extends TitleCard {
                 this.game.currentChallenge.anyParticipants(card => card.controller === this.controller)
             ),
             targetController: 'current',
-            effect: ability.effects.contributeChallengeStrength(this, 1)
+            effect: ability.effects.contributeStrength(this, 1)
         });
     }
 }

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -74,7 +74,7 @@ class Challenge {
     }
 
     removeContributionToAttack(card, type, amount) {
-        let contribution = this.attackerContributions.find(c => c.card === card, c.type === type, c.amount === amount);
+        let contribution = this.attackerContributions.find(c => c.card === card && c.type === type && c.amount === amount);
         if(contribution) {
             this.attackerContributions.splice(this.attackerContributions.indexOf(contribution), 1);
         }
@@ -101,7 +101,7 @@ class Challenge {
     }
 
     removeContributionToDefence(card, type, amount) {
-        let contribution = this.defenderContributions.find(c => c.card === card, c.type === type, c.amount === amount);
+        let contribution = this.defenderContributions.find(c => c.card === card && c.type === type && c.amount === amount);
         if(contribution) {
             this.defenderContributions.splice(this.defenderContributions.indexOf(contribution), 1);
         }
@@ -111,7 +111,7 @@ class Challenge {
         if(this.attackingPlayer === player) {
             this.addContributionToAttack(card, 'effect', amount);
         } else if(this.defendingPlayer === player) {
-            this.addContributionToDefend(card, 'effect', amount);
+            this.addContributionToDefence(card, 'effect', amount);
         }
         this.calculateStrength();
     }
@@ -120,7 +120,7 @@ class Challenge {
         if(this.attackingPlayer === player) {
             this.removeContributionToAttack(card, 'effect', amount);
         } else if(this.defendingPlayer === player) {
-            this.removeContributionToDefend(card, 'effect', amount);
+            this.removeContributionToDefence(card, 'effect', amount);
         }
         this.calculateStrength();
     }
@@ -231,7 +231,6 @@ class Challenge {
         if(this.winnerDetermined) {
             return;
         }
-
 
         this.attackerStrength = this.calculateStrengthFor(this.attackerContributions);
         this.defenderStrength = this.calculateStrengthFor(this.defenderContributions);

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -21,8 +21,8 @@ class Challenge {
         this.attackerContributions = [];
         this.attackerStrength = 0;
         this.defenders = [];
-        this.defenderStrength = 0;
         this.defenderContributions = [];
+        this.defenderStrength = 0;
         this.stealthData = [];
         this.assaultData = [];
         this.events = new EventRegistrar(game, this);

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -239,7 +239,7 @@ class Challenge {
     calculateStrengthFor(contributions) {
         return contributions.reduce((sum, contribution) => {
             let card = contribution.card;
-            if(card.challengeOptions && card.challengeOptions.contains('doesNotContributeStrength')) {
+            if(!contribution.amount && card.challengeOptions && card.challengeOptions.contains('doesNotContributeStrength')) {
                 return sum;
             }
 

--- a/server/game/challenge.js
+++ b/server/game/challenge.js
@@ -69,7 +69,8 @@ class Challenge {
         if(!amount) {
             this.clearDynamicContributions(card);
         }
-
+        
+        card.isContributing = true;
         this.attackerContributions.push({ card, type, amount });
     }
 
@@ -77,6 +78,7 @@ class Challenge {
         let contribution = this.attackerContributions.find(c => c.card === card && c.type === type && c.amount === amount);
         if(contribution) {
             this.attackerContributions.splice(this.attackerContributions.indexOf(contribution), 1);
+            card.isContributing = this.isContributingSTR(card);
         }
     }
 
@@ -97,6 +99,7 @@ class Challenge {
             this.clearDynamicContributions(card);
         }
 
+        card.isContributing = true;
         this.defenderContributions.push({ card, type, amount });
     }
 
@@ -104,6 +107,7 @@ class Challenge {
         let contribution = this.defenderContributions.find(c => c.card === card && c.type === type && c.amount === amount);
         if(contribution) {
             this.defenderContributions.splice(this.defenderContributions.indexOf(contribution), 1);
+            card.isContributing = this.isContributingSTR(card);
         }
     }
 
@@ -361,9 +365,11 @@ class Challenge {
     finish() {
         for(let card of this.attackers) {
             card.inChallenge = false;
+            card.isContributing = false;
         }
         for(let card of this.defenders) {
             card.inChallenge = false;
+            card.isContributing = false;
         }
         this.isInitiated = false;
     }

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -17,6 +17,7 @@ class ChatCommands {
             '/blank': this.blank,
             '/cancel-prompt': this.cancelPrompt,
             '/cancel-challenge': this.cancelChallenge,
+            '/challenge-str': this.currentChallengeStrength,
             '/discard': this.discard,
             '/disconnectme': this.disconnectMe,
             '/draw': this.draw,
@@ -328,6 +329,17 @@ class ChatCommands {
 
         this.game.addAlert('danger', '{0} uses /cancel-challenge to attempt to cancel the current challenge', player);
         this.game.queueStep(new CancelChallengePrompt(this.game, player));
+    }
+
+    currentChallengeStrength(player, args) {
+        if(!this.game.isDuringChallenge()) {
+            return;
+        }
+
+        let challenge = this.game.currentChallenge;
+        challenge.calculateStrength();
+
+        this.game.addAlert('info', '{0} is currently attacking with {1} STR, and {2} is currently defending with {3} STR', challenge.attackingPlayer, challenge.attackerStrength, challenge.defendingPlayer, challenge.defenderStrength);
     }
 
     setToken(player, args) {

--- a/server/game/chatcommands.js
+++ b/server/game/chatcommands.js
@@ -331,7 +331,7 @@ class ChatCommands {
         this.game.queueStep(new CancelChallengePrompt(this.game, player));
     }
 
-    currentChallengeStrength(player, args) {
+    currentChallengeStrength() {
         if(!this.game.isDuringChallenge()) {
             return;
         }

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -19,6 +19,7 @@ class DrawCard extends BaseCard {
         this.dominanceOptions = new ReferenceCountedSetProperty();
         this.kneeled = false;
         this.inChallenge = false;
+        this.isContributing = false;
         this.inDanger = false;
         this.saved = false;
         this.challengeOptions = new ReferenceCountedSetProperty();
@@ -374,6 +375,7 @@ class DrawCard extends BaseCard {
         this.stealth = false;
         this.stealthTarget = undefined;
         this.inChallenge = false;
+        this.isContributing = false;
     }
 
     kneelsAsAttacker(challengeType) {
@@ -489,6 +491,7 @@ class DrawCard extends BaseCard {
             iconsAdded: this.getIconsAdded(),
             iconsRemoved: this.getIconsRemoved(),
             inChallenge: this.inChallenge,
+            isContributing: this.isContributing,
             inDanger: this.inDanger,
             saved: this.saved,
             strength: this.getStrength(),

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -964,8 +964,7 @@ const Effects = {
             }
         };
     },
-    contributeChallengeStrength: function(valueOrCalculate) {
-        const calculate = (typeof valueOrCalculate === 'function') ? valueOrCalculate : () => valueOrCalculate;
+    contributeChallengeStrength: function(card, value) {
         return {
             targetType: 'player',
             apply: function(player, context) {
@@ -974,30 +973,10 @@ const Effects = {
                     return;
                 }
 
-                const value = calculate(context);
-                context.contributeChallengeStrength = context.contributeChallengeStrength || {};
-                context.contributeChallengeStrength[player.name] = value;
                 if(challenge.attackingPlayer === player) {
-                    challenge.modifyAttackerStrength(value);
+                    challenge.addContributeSTRToAttacker(card, value);
                 } else if(challenge.defendingPlayer === player) {
-                    challenge.modifyDefenderStrength(value);
-                }
-            },
-            reapply: function(player, context) {
-                let challenge = context.game.currentChallenge;
-                if(!challenge) {
-                    return;
-                }
-
-                context.contributeChallengeStrength = context.contributeChallengeStrength || {};
-                const origValue = context.contributeChallengeStrength[player.name];
-                const newValue = calculate(context);
-                const diff = newValue - origValue;
-                context.contributeChallengeStrength[player.name] = newValue;
-                if(challenge.attackingPlayer === player) {
-                    challenge.modifyAttackerStrength(diff);
-                } else if(challenge.defendingPlayer === player) {
-                    challenge.modifyDefenderStrength(diff);
+                    challenge.addContributeSTRToDefender(card, value);
                 }
             },
             unapply: function(player, context) {
@@ -1006,16 +985,12 @@ const Effects = {
                     return;
                 }
 
-                const value = calculate(context);
-                context.contributeChallengeStrength = context.contributeChallengeStrength || {};
-                delete context.contributeChallengeStrength[player.name];
                 if(challenge.attackingPlayer === player) {
-                    challenge.modifyAttackerStrength(-value);
+                    challenge.removeContributeStrToAttacker(card, value);
                 } else if(challenge.defendingPlayer === player) {
-                    challenge.modifyDefenderStrength(-value);
+                    challenge.removeContributeStrToDefender(card, value);
                 }
-            },
-            isStateDependent: true
+            }
         };
     },
     setAttackerMaximum: function(value) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -972,11 +972,18 @@ const Effects = {
                 if(!challenge) {
                     return;
                 }
+                challenge.addContributeSTRTowards(player, card, value);
+            },
+            reapply: function(player, context) {
+                let challenge = context.game.currentChallenge;
+                if(!challenge) {
+                    return;
+                }
 
-                if(challenge.attackingPlayer === player) {
-                    challenge.addContributeSTRToAttacker(card, value);
-                } else if(challenge.defendingPlayer === player) {
-                    challenge.addContributeSTRToDefender(card, value);
+                // To ensure participation isn't overridden by a effect when it was the most recent type of contribution
+                if(!challenge.isContributingSTR(card, 'participation')) {
+                    challenge.removeContributeSTRTowards(player, card, value);
+                    challenge.addContributeSTRTowards(player, card, value);
                 }
             },
             unapply: function(player, context) {
@@ -984,13 +991,9 @@ const Effects = {
                 if(!challenge) {
                     return;
                 }
-
-                if(challenge.attackingPlayer === player) {
-                    challenge.removeContributeStrToAttacker(card, value);
-                } else if(challenge.defendingPlayer === player) {
-                    challenge.removeContributeStrToDefender(card, value);
-                }
-            }
+                challenge.removeContributeSTRTowards(player, card, value);
+            },
+            isStateDependent: true
         };
     },
     setAttackerMaximum: function(value) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -2,6 +2,7 @@ const AbilityLimit = require('./abilitylimit.js');
 const AllowedChallenge = require('./AllowedChallenge');
 const CardMatcher = require('./CardMatcher');
 const CardTextDefinition = require('./CardTextDefinition');
+const {ValueContribution, CharacterStrengthContribution} = require('./ChallengeContributions');
 const CostReducer = require('./costreducer.js');
 const GameActions = require('./GameActions');
 const PlayableLocation = require('./playablelocation.js');
@@ -964,7 +965,8 @@ const Effects = {
             }
         };
     },
-    contributeChallengeStrength: function(card, value) {
+    contributeCharacterStrength: function(card) {
+        let contribution = null;
         return {
             targetType: 'player',
             apply: function(player, context) {
@@ -972,28 +974,41 @@ const Effects = {
                 if(!challenge) {
                     return;
                 }
-                challenge.addContributeSTRTowards(player, card, value);
-            },
-            reapply: function(player, context) {
-                let challenge = context.game.currentChallenge;
-                if(!challenge) {
-                    return;
-                }
 
-                // To ensure participation isn't overridden by a effect when it was the most recent type of contribution
-                if(!challenge.isContributingSTR(card, 'participation')) {
-                    challenge.removeContributeSTRTowards(player, card, value);
-                    challenge.addContributeSTRTowards(player, card, value);
-                }
+                contribution = new CharacterStrengthContribution(player, card);
+                challenge.addContribution(contribution);
             },
             unapply: function(player, context) {
                 let challenge = context.game.currentChallenge;
                 if(!challenge) {
                     return;
                 }
-                challenge.removeContributeSTRTowards(player, card, value);
+                
+                challenge.removeContribution(contribution);
+            }
+        };
+    },
+    contributeStrength: function(card, value) {
+        let contribution = null;
+        return {
+            targetType: 'player',
+            apply: function(player, context) {
+                let challenge = context.game.currentChallenge;
+                if(!challenge) {
+                    return;
+                }
+                
+                contribution = new ValueContribution(player, card, value);
+                challenge.addContribution(contribution);
             },
-            isStateDependent: true
+            unapply: function(player, context) {
+                let challenge = context.game.currentChallenge;
+                if(!challenge) {
+                    return;
+                }
+
+                challenge.removeContribution(contribution);
+            }
         };
     },
     setAttackerMaximum: function(value) {

--- a/test/server/cards/23-AHaH/AnyaWaynewood.spec.js
+++ b/test/server/cards/23-AHaH/AnyaWaynewood.spec.js
@@ -1,0 +1,122 @@
+describe('Anya Waynewood', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck = this.buildDeck('greyjoy', [
+                'Time of Plenty',
+                'Anya Waynwood', 'Lannisport Merchant', 'Lannisport Merchant', 'Lannisport Merchant', 'The Kingsroad'
+            ]);
+            this.player1.selectDeck(deck);
+            this.player2.selectDeck(deck);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.anya = this.player1.findCardByName('Anya Waynwood');
+            this.location = this.player1.findCardByName('The Kingsroad');
+            [this.merchant1, this.merchant2] = this.player1.filterCardsByName('Lannisport Merchant');
+            this.opponentAnya = this.player2.findCardByName('Anya Waynwood');
+            [this.opponentMerchant1, this.opponentMerchant2, this.opponentMerchant3] = this.player2.filterCardsByName('Lannisport Merchant');
+            this.opponentLocation = this.player2.findCardByName('The Kingsroad');
+            this.player1.clickCard(this.anya);
+            this.player1.clickCard(this.merchant1);
+            this.player1.clickCard(this.merchant2);
+            this.player2.clickCard(this.opponentAnya);
+            this.player2.clickCard(this.opponentMerchant1);
+            this.player2.clickCard(this.opponentMerchant2);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+
+            this.player1.clickCard(this.location);
+            this.player1.clickPrompt('Done');
+            this.player2.clickCard(this.opponentMerchant3);
+            this.player2.clickCard(this.opponentLocation);
+            this.player2.clickPrompt('Done');
+
+            // Give power to each player to help determine winners
+            this.player1Object.faction.power = 1;
+            this.player2Object.faction.power = 1;
+        });
+
+        describe('when used against a non-participating character', function() {
+            it('contributes their STR to the challenge', function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.merchant1);
+                this.player1.clickPrompt('Done');
+                this.skipActionWindow();
+                this.player2.clickCard(this.opponentMerchant1);
+                this.player2.clickCard(this.opponentMerchant2);
+                this.player2.clickPrompt('Done');
+
+                // Trigger ability
+                this.player1.clickMenu(this.anya, 'Contribute STR to challenge');
+                this.player1.clickCard(this.location);
+                this.player1.clickCard(this.opponentMerchant3);
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Pass');
+
+                this.player1.clickPrompt('Apply Claim');
+
+                expect(this.location.kneeled).toBe(true);
+                expect(this.player1Object.faction.power).toBe(2);
+                expect(this.player2Object.faction.power).toBe(0);
+            });
+        });
+
+        describe('when used early and the character is declared by opponent', function() {
+            it('the effect is overridden by declaring the character', function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.merchant1);
+                this.player1.clickPrompt('Done');
+
+                // Trigger ability
+                this.player1.clickMenu(this.anya, 'Contribute STR to challenge');
+                this.player1.clickCard(this.location);
+                this.player1.clickCard(this.opponentMerchant1);
+                this.player2.clickPrompt('Pass');
+                this.player1.clickPrompt('Pass');
+
+                this.player2.clickCard(this.opponentMerchant1);
+                this.player2.clickCard(this.opponentMerchant2);
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                expect(this.location.kneeled).toBe(true);
+                expect(this.player1Object.faction.power).toBe(1);
+                expect(this.player2Object.faction.power).toBe(1);
+                expect(this.player1).not.toHavePromptButton('Apply Claim');
+            });
+        });
+
+        describe('when used twice on the same character', function() {
+            it('the effect is overridden by declaring the character', function() {
+                this.player1.clickPrompt('Power');
+                this.player1.clickCard(this.merchant1);
+                this.player1.clickPrompt('Done');
+
+                // Trigger attacker ability
+                this.player1.clickMenu(this.anya, 'Contribute STR to challenge');
+                this.player1.clickCard(this.location);
+                this.player1.clickCard(this.opponentMerchant2);
+
+                // Trigger defender ability
+                this.player2.clickMenu(this.opponentAnya, 'Contribute STR to challenge');
+                this.player2.clickCard(this.opponentLocation);
+                this.player2.clickCard(this.opponentMerchant2);
+
+                this.skipActionWindow();
+
+                this.player2.clickCard(this.opponentMerchant1);
+                this.player2.clickPrompt('Done');
+
+                this.skipActionWindow();
+
+                expect(this.location.kneeled).toBe(true);
+                expect(this.player1Object.faction.power).toBe(1);
+                expect(this.player2Object.faction.power).toBe(1);
+                expect(this.player1).not.toHavePromptButton('Apply Claim');
+            });
+        });
+    });
+});

--- a/test/server/cards/23-AHaH/AnyaWaynewood.spec.js
+++ b/test/server/cards/23-AHaH/AnyaWaynewood.spec.js
@@ -90,7 +90,7 @@ describe('Anya Waynewood', function() {
         });
 
         describe('when used twice on the same character', function() {
-            it('the effect is overridden by declaring the character', function() {
+            it('the last effect takes precedence', function() {
                 this.player1.clickPrompt('Power');
                 this.player1.clickCard(this.merchant1);
                 this.player1.clickPrompt('Done');

--- a/test/server/cards/23-AHaH/AnyaWaynwood.spec.js
+++ b/test/server/cards/23-AHaH/AnyaWaynwood.spec.js
@@ -1,4 +1,4 @@
-describe('Anya Waynewood', function() {
+describe('Anya Waynwood', function() {
     integration(function() {
         beforeEach(function() {
             const deck = this.buildDeck('greyjoy', [

--- a/test/server/challenge/contributeStrength.spec.js
+++ b/test/server/challenge/contributeStrength.spec.js
@@ -1,0 +1,316 @@
+const Challenge = require('../../../server/game/challenge.js');
+const Player = require('../../../server/game/player.js');
+const DrawCard = require('../../../server/game/drawcard.js');
+
+describe('Challenge', function() {
+    beforeEach(function() {
+        this.gameSpy = jasmine.createSpyObj('game', ['applyGameAction', 'on', 'raiseEvent']);
+        this.gameSpy.applyGameAction.and.callFake((type, card, handler) => {
+            handler(card);
+        });
+
+        this.attackingPlayer = new Player('1', { username: 'Player 1', settings: {} }, true, this.gameSpy);
+        this.defendingPlayer = new Player('2', { username: 'Player 2', settings: {} }, true, this.gameSpy);
+
+        this.attackerCard = new DrawCard(this.attackingPlayer, {});
+        this.defenderCard = new DrawCard(this.defendingPlayer, {});
+
+        this.challenge = new Challenge(this.gameSpy, { attackingPlayer: this.attackingPlayer, defendingPlayer: this.defendingPlayer, challengeType: 'military' });
+        
+        spyOn(this.attackerCard, 'getStrength').and.returnValue(5);
+        spyOn(this.defenderCard, 'getStrength').and.returnValue(5);
+
+        this.challenge.addAttackers([this.attackerCard]);
+        this.challenge.addDefenders([this.defenderCard]);
+
+        this.initialAttackerSTR = this.challenge.attackerStrength;
+        this.initialDefenderSTR = this.challenge.defenderStrength;
+    });
+
+    describe('addContributeSTRTowards()', function() {
+        describe('when the target is controlled by the attacking player', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.attackingPlayer, {});
+            });
+
+            describe('and is contributing 2 STR towards the attacking player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 2);
+                });
+
+                it('should result in attacker\'s total being raised by 2', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + 2);
+                });
+
+                it('should result in defender\'s total STR being unchanged', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                });
+
+                describe('as well as 4 STR towards the defending player\'s side', function() {
+                    beforeEach(function() {
+                        this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 4);
+                    });
+
+                    it('should result in attacker\'s total being raised by 2', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + 2);
+                    });
+    
+                    it('should result in defender\'s total STR being raised by 4', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + 4);
+                    });
+                });
+            });
+
+            describe('and is contributing 2 STR towards the defending player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 2);
+                });
+
+                it('should result in attacker\'s total being unchanged', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                });
+
+                it('should result in defender\'s total STR being raised by 2', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + 2);
+                });
+
+                describe('as well as 4 STR towards the attacking player\'s side', function() {
+                    beforeEach(function() {
+                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 4);
+                    });
+
+                    it('should result in attacker\'s total STR being raised by 4', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + 4);
+                    });
+    
+                    it('should result in defender\'s total STR being raised by 2', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + 2);
+                    });
+                });
+            });
+
+            describe('and is a character contributing it\'s STR (6)', function() {
+                beforeEach(function() {
+                    spyOn(this.targetCard, 'getStrength').and.returnValue(6);
+                });
+
+                describe('towards the attacking player\'s side', function() {
+                    beforeEach(function() {
+                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                    });
+
+                    it('should result in attacker\'s total STR being raised by that STR', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + this.targetCard.getStrength());
+                    });
+    
+                    it('should result in defender\'s total STR being unchanged', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+
+                    describe('then towards the defending player\'s side', function() {
+                        beforeEach(function() {
+                            this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                        });
+
+                        it('should result in attacker\'s total STR being unchanged', function() {
+                            expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                        });
+        
+                        it('should result in defender\'s total STR being raised by that STR', function() {
+                            expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + this.targetCard.getStrength());
+                        });
+                    });
+
+                    describe('then cannot contribute its STR towards the challenge', function() {
+                        beforeEach(function() {
+                            this.targetCard.challengeOptions.add('doesNotContributeStrength');
+                            this.challenge.calculateStrength();
+                        });
+    
+                        it('should result in attacker\'s total STR being unchanged', function() {
+                            expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                        });
+    
+                        it('should result in defender\'s total STR being unchanged', function() {
+                            expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                        });
+                    });
+                });
+            });
+        });
+
+        describe('when the target is controlled by the defending player', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.defendingPlayer, {});
+            });
+            describe('and is contributing 2 STR towards the attacking player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 2);
+                });
+
+                it('should result in attacker\'s total being raised by 2', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + 2);
+                });
+
+                it('should result in defender\'s total STR being unchanged', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                });
+            });
+        });
+
+        describe('when the target is already participating as an attacker in the challenge', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.attackingPlayer, {});
+
+                spyOn(this.targetCard, 'getStrength').and.returnValue(5);
+
+                this.challenge.addAttackers([this.targetCard]);
+
+                this.initialAttackerSTR = this.challenge.attackerStrength;
+            });
+
+            describe('and it contributes 3 STR towards the attacking player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 3);
+                });
+
+                it('should result in attacker\'s total STR being raised by 3', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR + 3);
+                });
+
+                it('should result in defender\'s total STR being unchanged', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                });
+            });
+
+            describe('and it contributes 3 STR towards the defending player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 3);
+                });
+
+                it('should result in attacker\'s total STR being unchanged', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                });
+
+                it('should result in defender\'s total STR being raised by 3', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + 3);
+                });
+            });
+
+            describe('and it contributes it\'s STR (5) towards the attacking player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                });
+
+                it('should result in attacker\'s total STR being unchanged', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                });
+
+                it('should result in defender\'s total STR being unchanged', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                });
+
+                describe('then is removed from the challenge', function() {
+                    beforeEach(function() {
+                        this.challenge.removeFromChallenge(this.targetCard);
+                    });
+
+                    it('should result in attacker\'s total STR being unchanged', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                    });
+    
+                    it('should result in defender\'s total STR being unchanged', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+                });
+            });
+
+            describe('and it contributes it\'s STR (5) towards the defending player\'s side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                });
+
+                it('should result in attacker\'s total STR being reduced by that STR', function() {
+                    expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR - this.targetCard.getStrength());
+                });
+
+                it('should result in defender\'s total STR being raised by that STR', function() {
+                    expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + this.targetCard.getStrength());
+                });
+
+                describe('then contributes to the attacking player\'s side again', function() {
+                    beforeEach(function() {
+                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                    });
+
+                    it('should result in attacker\'s total STR being unchanged', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                    });
+
+                    it('should result in defender\'s total STR being unchanged', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+                });
+
+                describe('then has it\'s STR raised (by 2)', function() {
+                    beforeEach(function() {
+                        this.previousTargetCardSTR = this.targetCard.getStrength();
+                        this.targetCard.getStrength.and.returnValue(this.targetCard.getStrength() + 2);
+                        this.challenge.calculateStrength();
+                    });
+
+                    it('should result in attacker\'s total STR being reduced by the previous STR', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR - this.previousTargetCardSTR);
+                    });
+
+                    it('should result in defender\'s total STR being raised by the new STR', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR + this.targetCard.getStrength());
+                    });
+                });
+
+                describe('then cannot contribute its STR towards the challenge', function() {
+                    beforeEach(function() {
+                        this.targetCard.challengeOptions.add('doesNotContributeStrength');
+                        this.challenge.calculateStrength();
+                    });
+
+                    it('should result in attacker\'s total STR being reduced by that STR', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR - this.targetCard.getStrength());
+                    });
+
+                    it('should result in defender\'s total STR being unchanged', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+                });
+            });
+        });
+    });
+
+    describe('removeContributeSTRTowards()', function() {
+        describe('when the target is controlled by attacking player', function() {
+            beforeEach(function() {
+                this.targetCard = new DrawCard(this.attackingPlayer, {});
+            });
+
+            describe('then contributes it\'s STR to the defenders side', function() {
+                beforeEach(function() {
+                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                });
+
+                describe('then no longer contributes it\'s STR to the defenders side', function() {
+                    beforeEach(function() {
+                        this.challenge.removeContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                    });
+
+                    it('should result in attacker\'s total STR being unchanged', function() {
+                        expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                    });
+        
+                    it('should result in defender\'s total STR being unchanged', function() {
+                        expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/test/server/challenge/contributeStrength.spec.js
+++ b/test/server/challenge/contributeStrength.spec.js
@@ -1,6 +1,7 @@
 const Challenge = require('../../../server/game/challenge.js');
 const Player = require('../../../server/game/player.js');
 const DrawCard = require('../../../server/game/drawcard.js');
+const {ValueContribution, CharacterStrengthContribution} = require('../../../server/game/ChallengeContributions.js');
 
 describe('Challenge', function() {
     beforeEach(function() {
@@ -27,7 +28,7 @@ describe('Challenge', function() {
         this.initialDefenderSTR = this.challenge.defenderStrength;
     });
 
-    describe('addContributeSTRTowards()', function() {
+    describe('addContribution()', function() {
         describe('when the target is controlled by the attacking player', function() {
             beforeEach(function() {
                 this.targetCard = new DrawCard(this.attackingPlayer, {});
@@ -35,7 +36,8 @@ describe('Challenge', function() {
 
             describe('and is contributing 2 STR towards the attacking player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 2);
+                    this.contribution1 = new ValueContribution(this.attackingPlayer, this.targetCard, 2);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total being raised by 2', function() {
@@ -48,7 +50,8 @@ describe('Challenge', function() {
 
                 describe('as well as 4 STR towards the defending player\'s side', function() {
                     beforeEach(function() {
-                        this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 4);
+                        this.contribution2 = new ValueContribution(this.defendingPlayer, this.targetCard, 4);
+                        this.challenge.addContribution(this.contribution2);
                     });
 
                     it('should result in attacker\'s total being raised by 2', function() {
@@ -63,7 +66,8 @@ describe('Challenge', function() {
 
             describe('and is contributing 2 STR towards the defending player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 2);
+                    this.contribution1 = new ValueContribution(this.defendingPlayer, this.targetCard, 2);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total being unchanged', function() {
@@ -76,7 +80,8 @@ describe('Challenge', function() {
 
                 describe('as well as 4 STR towards the attacking player\'s side', function() {
                     beforeEach(function() {
-                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 4);
+                        this.contribution2 = new ValueContribution(this.attackingPlayer, this.targetCard, 4);
+                        this.challenge.addContribution(this.contribution2);
                     });
 
                     it('should result in attacker\'s total STR being raised by 4', function() {
@@ -96,7 +101,8 @@ describe('Challenge', function() {
 
                 describe('towards the attacking player\'s side', function() {
                     beforeEach(function() {
-                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                        this.contribution1 = new CharacterStrengthContribution(this.attackingPlayer, this.targetCard);
+                        this.challenge.addContribution(this.contribution1);
                     });
 
                     it('should result in attacker\'s total STR being raised by that STR', function() {
@@ -109,7 +115,8 @@ describe('Challenge', function() {
 
                     describe('then towards the defending player\'s side', function() {
                         beforeEach(function() {
-                            this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                            this.contribution2 = new CharacterStrengthContribution(this.defendingPlayer, this.targetCard);
+                            this.challenge.addContribution(this.contribution2);
                         });
 
                         it('should result in attacker\'s total STR being unchanged', function() {
@@ -145,7 +152,8 @@ describe('Challenge', function() {
             });
             describe('and is contributing 2 STR towards the attacking player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 2);
+                    this.contribution1 = new ValueContribution(this.attackingPlayer, this.targetCard, 2);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total being raised by 2', function() {
@@ -171,7 +179,8 @@ describe('Challenge', function() {
 
             describe('and it contributes 3 STR towards the attacking player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard, 3);
+                    this.contribution1 = new ValueContribution(this.attackingPlayer, this.targetCard, 3);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total STR being raised by 3', function() {
@@ -185,7 +194,8 @@ describe('Challenge', function() {
 
             describe('and it contributes 3 STR towards the defending player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard, 3);
+                    this.contribution1 = new ValueContribution(this.defendingPlayer, this.targetCard, 3);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total STR being unchanged', function() {
@@ -199,7 +209,8 @@ describe('Challenge', function() {
 
             describe('and it contributes it\'s STR (5) towards the attacking player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                    this.contribution1 = new CharacterStrengthContribution(this.attackingPlayer, this.targetCard);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total STR being unchanged', function() {
@@ -227,7 +238,8 @@ describe('Challenge', function() {
 
             describe('and it contributes it\'s STR (5) towards the defending player\'s side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                    this.contribution1 = new CharacterStrengthContribution(this.defendingPlayer, this.targetCard);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 it('should result in attacker\'s total STR being reduced by that STR', function() {
@@ -240,7 +252,8 @@ describe('Challenge', function() {
 
                 describe('then contributes to the attacking player\'s side again', function() {
                     beforeEach(function() {
-                        this.challenge.addContributeSTRTowards(this.attackingPlayer, this.targetCard);
+                        this.contribution2 = new CharacterStrengthContribution(this.attackingPlayer, this.targetCard);
+                        this.challenge.addContribution(this.contribution2);
                     });
 
                     it('should result in attacker\'s total STR being unchanged', function() {
@@ -249,6 +262,20 @@ describe('Challenge', function() {
 
                     it('should result in defender\'s total STR being unchanged', function() {
                         expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                    });
+
+                    describe('then is removed from the challenge', function() {
+                        beforeEach(function() {
+                            this.challenge.removeFromChallenge(this.targetCard);
+                        });
+    
+                        it('should result in attacker\'s total STR being unchanged', function() {
+                            expect(this.challenge.attackerStrength).toBe(this.initialAttackerSTR);
+                        });
+        
+                        it('should result in defender\'s total STR being unchanged', function() {
+                            expect(this.challenge.defenderStrength).toBe(this.initialDefenderSTR);
+                        });
                     });
                 });
 
@@ -286,7 +313,7 @@ describe('Challenge', function() {
         });
     });
 
-    describe('removeContributeSTRTowards()', function() {
+    describe('removeContribution()', function() {
         describe('when the target is controlled by attacking player', function() {
             beforeEach(function() {
                 this.targetCard = new DrawCard(this.attackingPlayer, {});
@@ -294,12 +321,13 @@ describe('Challenge', function() {
 
             describe('then contributes it\'s STR to the defenders side', function() {
                 beforeEach(function() {
-                    this.challenge.addContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                    this.contribution1 = new CharacterStrengthContribution(this.defendingPlayer, this.targetCard);
+                    this.challenge.addContribution(this.contribution1);
                 });
 
                 describe('then no longer contributes it\'s STR to the defenders side', function() {
                     beforeEach(function() {
-                        this.challenge.removeContributeSTRTowards(this.defendingPlayer, this.targetCard);
+                        this.challenge.removeContribution(this.contribution1);
                     });
 
                     it('should result in attacker\'s total STR being unchanged', function() {


### PR DESCRIPTION
This is primarily to account for Anya Waynwood & Lord Protector of the Vale, which can both have a non-participating character contribute their STR to a challenge. Close #195 

Summary of why this adjustment was required:
- Note that when a character is declared as an attacker or defender (known as it "Participating"), it is noted as "contributing its strength to its controllers side of the challenge". This is relevant for the next point.
- When multiple effects (including 'participation') are causing a character to "contribute its strength to a players side of the challenge", the latest effect prevails (similar to something like "take control"). For example, if I declare a challenge and immediately use Anya to have the opponents character contribute to my side, and then they declare that character as a defender, it contributes its STR to the defenders side, not my side, as the declaration as a defender ('participation') was the latest effect.
- Any "does not contribute its STR" abilities need to affect any cards contributing STR (as long as it targets it), regardless of whether they are participating or not. So for example, if I use Anya to have a character with 3 STR contribute to my side (without participating) whilst I am attacking with Theon Greyjoy (TFoA), that character should contribute 0 STR.
- A character can only "contribute its STR" once (no 'double contributing'), towards a single player during a challenge.
- "contributing its STR" (eg. Anya Waynwood) is dynamic with that characters STR, which is slightly different to a card contributing a static amount of STR (eg. The Red Keep (Core)).
- Cards contributing a static number of STR via an effect will always contribute that STR while the effect is active, regardless of if (or who) that card is contributing **its** STR to. This currently does not apply to any characters, but if a future character said something like `[this character] contributes 2 STR towards your side of the challenge during power challenges`, this update ensures that it always contributes 2 STR separately to whether its participating, or contributing **its** STR via another card ability (such as Lord Protector of the Vale).