### PR TITLE
Altering keyword limits to be a dynamic modifier within KeywordsProperty

### DIFF
--- a/server/game/PropertyTypes/KeywordsProperty.js
+++ b/server/game/PropertyTypes/KeywordsProperty.js
@@ -8,6 +8,7 @@ class KeywordsProperty {
         this.bestowMaxes = [];
         this.shadowCosts = [];
         this.prizedValues = [];
+        this.limitModifiers = new KeywordLimitModifiers();
     }
 
     add(value) {
@@ -98,6 +99,42 @@ class KeywordsProperty {
         }
 
         return values.reduce((a, b) => func(a, b));
+    }
+
+    raiseLimit(value, amount) {
+        this.limitModifiers.raise(value, amount);
+    }
+    
+    lowerLimit(value, amount) {
+        this.limitModifiers.lower(value, amount);
+    }
+
+    getLimitModifier(value) {
+        return this.limitModifiers.get(value);
+    }
+}
+
+class KeywordLimitModifiers {
+    constructor() {
+        this.limitModifiers = new Map();
+    }
+
+    raise(value, amount) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        this.limitModifiers.set(lowerCaseValue, currentModifier + amount);
+    }
+
+    lower(value, amount) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        this.limitModifiers.set(lowerCaseValue, currentModifier - amount);
+    }
+
+    get(value) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        return currentModifier;
     }
 }
 

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -396,6 +396,10 @@ class BaseCard {
         return this.keywords.getPrizedValue();
     }
 
+    getKeywordLimitModifier(keyword) {
+        return this.keywords.getLimitModifier(keyword);
+    }
+
     hasTrait(trait) {
         if(this.losesAspects.contains('traits')) {
             return false;
@@ -650,6 +654,10 @@ class BaseCard {
         this.keywords.add(keyword);
     }
 
+    raiseKeywordLimit(keyword, amount) {
+        this.keywords.raiseLimit(keyword, amount);
+    }
+
     addTrait(trait) {
         this.traits.add(trait);
 
@@ -677,6 +685,10 @@ class BaseCard {
 
     removeKeyword(keyword) {
         this.keywords.remove(keyword);
+    }
+
+    lowerKeywordLimit(keyword, amount) {
+        this.keywords.lowerLimit(keyword, amount);
     }
 
     removeTrait(trait) {

--- a/server/game/cards/24-TSoW/KingRobbsBannermen.js
+++ b/server/game/cards/24-TSoW/KingRobbsBannermen.js
@@ -1,24 +1,11 @@
 const DrawCard = require('../../drawcard.js');
-const GameActions = require('../../GameActions/index.js');
 
 class KingRobbsBannermen extends DrawCard {
-    setupCardAbilities() {
-        this.reaction({
-            when: {
-                afterChallenge: event => event.challenge.isMatch({ winner: this.controller, challengeType: 'military' }) 
-                                            && this.controller.anyCardsInPlay(card => card.isAttacking() &&
-                                                card.hasTrait('King') &&
-                                                card.getType() === 'character')
-            },
-            target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: { type: 'character', participating: false, condition: (card, context) => card.controller === context.event.challenge.loser },
-                gameAction: 'kill'
-            },
-            message: '{player} uses {source} to kill {target}',
-            handler: context => {
-                this.game.resolveGameAction(GameActions.kill(context => ({ card: context.target, player: context.player })), context);
-            }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.controller.anyCardsInPlay(card => card.isFaction('stark') && card.hasTrait('King')),
+            match: this,
+            effect: ability.effects.addAssaultLimit(1)
         });
     }
 }

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -23,8 +23,6 @@ class DrawCard extends BaseCard {
         this.inDanger = false;
         this.saved = false;
         this.challengeOptions = new ReferenceCountedSetProperty();
-        this.stealthLimit = 1;
-        this.pillageLimit = 1;
         this.minCost = 0;
         this.eventPlacementLocation = 'discard pile';
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -327,20 +327,30 @@ const Effects = {
     addStealthLimit: function(value) {
         return {
             apply: function(card) {
-                card.stealthLimit += value;
+                card.raiseKeywordLimit('stealth', value);
             },
             unapply: function(card) {
-                card.stealthLimit -= value;
+                card.lowerKeywordLimit('stealth', value);
             }
         };
     },
     addPillageLimit: function(value) {
         return {
             apply: function(card) {
-                card.pillageLimit += value;
+                card.raiseKeywordLimit('pillage', value);
             },
             unapply: function(card) {
-                card.pillageLimit -= value;
+                card.lowerKeywordLimit('pillage', value);
+            }
+        };
+    },
+    addAssaultLimit: function(value) {
+        return {
+            apply: function(card) {
+                card.raiseKeywordLimit('assault', value);
+            },
+            unapply: function(card) {
+                card.lowerKeywordLimit('assault', value);
             }
         };
     },

--- a/server/game/gamesteps/challenge/ChooseAssaultTargets.js
+++ b/server/game/gamesteps/challenge/ChooseAssaultTargets.js
@@ -18,10 +18,11 @@ class ChooseAssaultTargets extends BaseStep {
         if(this.assaultCharacters.length > 0 && !this.assaultTargetChosen) {
             let highestPrintedCost = Math.max(...this.assaultCharacters.map(character => character.getPrintedCost()));
             let characterWithHighestPrintedCost = this.assaultCharacters.find(character => character.getPrintedCost() === highestPrintedCost);
-            
-            let title = 'Select assault target for ' + characterWithHighestPrintedCost.name;
+            // Keyword modifier adjusts the number of locations that can be targeted using assault
+            let numTargets = 1 + characterWithHighestPrintedCost.getKeywordLimitModifier('assault');
+            let title = `Select ${numTargets === 1 ? 'assault target' : `up to ${numTargets} assault targets`} for ${characterWithHighestPrintedCost.name}`;
             this.game.promptForSelect(characterWithHighestPrintedCost.controller, {
-                numCards: 1,
+                numCards: numTargets,
                 activePromptTitle: title,
                 waitingPromptTitle: 'Waiting for opponent to choose assault target for ' + characterWithHighestPrintedCost.name,
                 cardCondition: card => this.canAssault(card, this.challenge, characterWithHighestPrintedCost),

--- a/server/game/gamesteps/challenge/ChooseStealthTargets.js
+++ b/server/game/gamesteps/challenge/ChooseStealthTargets.js
@@ -15,10 +15,11 @@ class ChooseStealthTargets extends BaseStep {
     continue() {
         if(this.stealthCharacters.length > 0) {
             let character = this.stealthCharacters.shift();
-
-            let title = character.stealthLimit === 1 ? 'Select stealth target for ' + character.name : 'Select up to ' + character.stealthLimit + ' stealth targets for ' + character.name;
+            // Keyword modifier adjusts the number of characters that can be bypassed using stealth
+            let numTargets = 1 + character.getKeywordLimitModifier('stealth');
+            let title = `Select ${numTargets === 1 ? 'stealth target' : `up to ${numTargets} stealth targets`} for ${character.name}`;
             this.game.promptForSelect(character.controller, {
-                numCards: character.stealthLimit,
+                numCards: numTargets,
                 activePromptTitle: title,
                 waitingPromptTitle: 'Waiting for opponent to choose stealth target for ' + character.name,
                 cardCondition: card => this.canStealth(card, this.challenge, character),

--- a/server/game/pillagekeyword.js
+++ b/server/game/pillagekeyword.js
@@ -12,7 +12,9 @@ class PillageKeyword extends BaseAbility {
 
     executeHandler(context) {
         let {game, challenge, source} = context;
-        game.raiseEvent('onPillage', { source: source, numCards: source.pillageLimit }, event => {
+        // Keyword modifier adjusts the number of cards discarded for pillage
+        let amount = 1 + source.getKeywordLimitModifier('pillage');
+        game.raiseEvent('onPillage', { source: source, numCards: amount }, event => {
             challenge.loser.discardFromDraw(event.numCards, cards => {
                 game.addMessage('{0} discards {1} from the top of their deck due to Pillage from {2}', challenge.loser, cards, source);
             }, { isPillage: true, source: source });


### PR DESCRIPTION
Future-proofing keyword limiter adjustments, currently with _stealth_, _pillage_ and now _assault_.

Works with creating a new limit modifier class within the keywords property to essentially work for any keyword when it arises.

Additionally, implements King Robbs Bannermen v 1.2, which can have its assault limit raised.