### PR TITLE
Updating Playtesting Website (v24.6)

### DIFF
--- a/server/game/GameActions/AssaultkeywordAction.js
+++ b/server/game/GameActions/AssaultkeywordAction.js
@@ -31,12 +31,16 @@ class AssaultKeywordAction extends GameAction {
                 match: target,
                 effect: ability.effects.blankExcludingTraits
             }));
-            challenge.game.once('afterChallenge', event => {
-                if(event.challenge.winner === source.controller && target.allowGameAction('kneel')) {
-                    challenge.game.addMessage('{0} kneels {1} due to assault', source.controller, target);
-                    challenge.game.resolveGameAction(GameActions.kneelCard({ card: target, source: source, cause: 'assault' }));
-                }
-            });
+        });
+    }
+
+    setupSimultaneousKneel({ challenge }) {
+        challenge.game.once('afterChallenge', event => {
+            let successful = event.challenge.assaultData.filter(assaultChoice => event.challenge.winner === assaultChoice.source.controller && assaultChoice.target.allowGameAction('kneel'));
+            if(successful.length > 1) {
+                event.challenge.game.addMessage('{0} kneels {1} due to assault', event.challenge.winner, successful.map(assaultChoice => assaultChoice.target));
+                event.challenge.game.resolveGameAction(GameActions.simultaneously(successful.map(assaultChoice => GameActions.kneelCard({ card: assaultChoice.target, source: assaultChoice.source, cause: 'assault' }))));
+            }
         });
     }
 }

--- a/server/game/GameActions/AssaultkeywordAction.js
+++ b/server/game/GameActions/AssaultkeywordAction.js
@@ -20,7 +20,7 @@ class AssaultKeywordAction extends GameAction {
             target.controller === challenge.defendingPlayer &&
             target.location === 'play area' &&
             target.getType() === 'location' &&
-            target.getPrintedCost() < source.getPrintedCost() &&
+            (source.challengeOptions.contains('ignoresAssaultLocationCost') || target.getPrintedCost() < source.getPrintedCost()) &&
             target.allowGameAction(this.name)
         );
     }

--- a/server/game/GameActions/InitiateChallenge.js
+++ b/server/game/GameActions/InitiateChallenge.js
@@ -21,6 +21,8 @@ class InitiateChallenge extends GameAction {
             
             challenge.stealthData.forEach(stealthChoice => event.thenAttachEvent(BypassByStealth.createEvent({ challenge, source: stealthChoice.source, target: stealthChoice.target })));
             challenge.assaultData.forEach(assaultChoice => event.thenAttachEvent(AssaultKeywordAction.createEvent({ challenge, source: assaultChoice.source, target: assaultChoice.target })));
+            // Grouping the kneel events for assault to ensure interrupts/reactions to multiple kneels are treated as simultaneous
+            AssaultKeywordAction.setupSimultaneousKneel({ challenge });
 
             event.thenExecute(event => {
                 // Reapply effects which rely on being within a challenge (eg. The Lord of the Crossing)

--- a/server/game/PropertyTypes/KeywordsProperty.js
+++ b/server/game/PropertyTypes/KeywordsProperty.js
@@ -8,6 +8,7 @@ class KeywordsProperty {
         this.bestowMaxes = [];
         this.shadowCosts = [];
         this.prizedValues = [];
+        this.limitModifiers = new KeywordLimitModifiers();
     }
 
     add(value) {
@@ -98,6 +99,42 @@ class KeywordsProperty {
         }
 
         return values.reduce((a, b) => func(a, b));
+    }
+
+    raiseLimit(value, amount) {
+        this.limitModifiers.raise(value, amount);
+    }
+    
+    lowerLimit(value, amount) {
+        this.limitModifiers.lower(value, amount);
+    }
+
+    getLimitModifier(value) {
+        return this.limitModifiers.get(value);
+    }
+}
+
+class KeywordLimitModifiers {
+    constructor() {
+        this.limitModifiers = new Map();
+    }
+
+    raise(value, amount) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        this.limitModifiers.set(lowerCaseValue, currentModifier + amount);
+    }
+
+    lower(value, amount) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        this.limitModifiers.set(lowerCaseValue, currentModifier - amount);
+    }
+
+    get(value) {
+        let lowerCaseValue = value.toLowerCase();
+        let currentModifier = this.limitModifiers.get(lowerCaseValue) || 0;
+        return currentModifier;
     }
 }
 

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -396,6 +396,10 @@ class BaseCard {
         return this.keywords.getPrizedValue();
     }
 
+    getKeywordLimitModifier(keyword) {
+        return this.keywords.getLimitModifier(keyword);
+    }
+
     hasTrait(trait) {
         if(this.losesAspects.contains('traits')) {
             return false;
@@ -650,6 +654,10 @@ class BaseCard {
         this.keywords.add(keyword);
     }
 
+    raiseKeywordLimit(keyword, amount) {
+        this.keywords.raiseLimit(keyword, amount);
+    }
+
     addTrait(trait) {
         this.traits.add(trait);
 
@@ -677,6 +685,10 @@ class BaseCard {
 
     removeKeyword(keyword) {
         this.keywords.remove(keyword);
+    }
+
+    lowerKeywordLimit(keyword, amount) {
+        this.keywords.lowerLimit(keyword, amount);
     }
 
     removeTrait(trait) {

--- a/server/game/cards/24-TSoW/CaggoCorpsekiller.js
+++ b/server/game/cards/24-TSoW/CaggoCorpsekiller.js
@@ -5,8 +5,8 @@ class CaggoCorpsekiller extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCardReturnedToHand: event => event.card.getType() === 'character' && event.cardStateWhenMoved.location === 'play area',
-                onCardPutIntoShadows: event => event.card.getType() === 'character' && event.cardStateWhenMoved.location === 'play area'
+                onCardReturnedToHand: event => event.card.getType() === 'character' && event.card.location === 'play area',
+                onCardPutIntoShadows: event => event.card.getType() === 'character' && event.card.location === 'play area'
             },
             cost: ability.costs.kneelSelf(),
             message: {

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -9,7 +9,7 @@ class Dragonstone extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardPutIntoShadows: event => event.card.location === 'play area'
+                onCardPutIntoShadows: () => true
             },
             message: {
                 format: '{player} returns {source} to shadows to discard {card}',

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -3,6 +3,10 @@ const GameActions = require('../../GameActions');
 
 class Dragonstone extends DrawCard {
     setupCardAbilities(ability) {
+        this.persistentEffect({
+            targetController: 'current',
+            effect: ability.effects.reduceFirstPlayedCardCostEachRound(1, card => card.getType() === 'event')
+        });
         this.reaction({
             when: {
                 onCardPutIntoShadows: event => event.card.location === 'play area',

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -5,7 +5,7 @@ class Dragonstone extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                onCardPutIntoShadows: () => true
+                onCardPutIntoShadows: event => event.card.location === 'play area',
             },
             message: {
                 format: '{player} returns {source} to shadows to discard {card}',

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -9,7 +9,7 @@ class Dragonstone extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardPutIntoShadows: event => event.card.location === 'play area',
+                onCardPutIntoShadows: event => event.card.location === 'play area'
             },
             message: {
                 format: '{player} returns {source} to shadows to discard {card}',

--- a/server/game/cards/24-TSoW/HighgardenSept.js
+++ b/server/game/cards/24-TSoW/HighgardenSept.js
@@ -3,9 +3,6 @@ const GameActions = require('../../GameActions/index.js');
 
 class HighgardenSept extends DrawCard {
     setupCardAbilities(ability) {
-        this.plotModifiers({
-            reserve: 1
-        });
         this.persistentEffect({
             condition: () => this.controller.hand.length >= 7,
             targetController: 'any',
@@ -13,8 +10,8 @@ class HighgardenSept extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardPowerGained: event => this.isControlledCharacter(event.card),
-                onCardPowerMoved: event => this.isControlledCharacter(event.target)
+                onCardPowerGained: event => this.isValidCard(event.card),
+                onCardPowerMoved: event => this.isValidCard(event.target)
             },
             limit: ability.limit.perPhase(1),
             message: '{player} uses {source} to draw 1 card',
@@ -22,8 +19,8 @@ class HighgardenSept extends DrawCard {
         });
     }
 
-    isControlledCharacter(card) {
-        return card.getType() === 'character' && card.controller === this.controller;
+    isValidCard(card) {
+        return card.hasTrait('The Seven') && card.controller === this.controller;
     }
 }
 

--- a/server/game/cards/24-TSoW/KingRobbsBannermen.js
+++ b/server/game/cards/24-TSoW/KingRobbsBannermen.js
@@ -1,24 +1,11 @@
 const DrawCard = require('../../drawcard.js');
-const GameActions = require('../../GameActions/index.js');
 
 class KingRobbsBannermen extends DrawCard {
-    setupCardAbilities() {
-        this.reaction({
-            when: {
-                afterChallenge: event => event.challenge.isMatch({ winner: this.controller, challengeType: 'military' }) 
-                                            && this.controller.anyCardsInPlay(card => card.isAttacking() &&
-                                                card.hasTrait('King') &&
-                                                card.getType() === 'character')
-            },
-            target: {
-                activePromptTitle: 'Select a character',
-                cardCondition: { type: 'character', participating: false, condition: (card, context) => card.controller === context.event.challenge.loser },
-                gameAction: 'kill'
-            },
-            message: '{player} uses {source} to kill {target}',
-            handler: context => {
-                this.game.resolveGameAction(GameActions.kill(context => ({ card: context.target, player: context.player })), context);
-            }
+    setupCardAbilities(ability) {
+        this.persistentEffect({
+            condition: () => this.controller.anyCardsInPlay(card => card.isFaction('stark') && card.hasTrait('King')),
+            match: this,
+            effect: ability.effects.addAssaultLimit(1)
         });
     }
 }

--- a/server/game/cards/24-TSoW/KingsLandingMob.js
+++ b/server/game/cards/24-TSoW/KingsLandingMob.js
@@ -4,12 +4,8 @@ const GameActions = require('../../GameActions/index.js');
 class KingsLandingMob extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            location: 'any',
-            targetController: 'current',
-            effect: [
-                ability.effects.reduceSelfCost('marshal', () => this.controller.getTotalReserve()),
-                ability.effects.setMinCost(4)
-            ]
+            match: this,
+            effect: ability.effects.ignoresAssaultLocationCost()
         });
         this.reaction({
             when: {

--- a/server/game/cards/24-TSoW/OxcrossSurvivors.js
+++ b/server/game/cards/24-TSoW/OxcrossSurvivors.js
@@ -4,6 +4,7 @@ class OxcrossSurvivors extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
             condition: () => this.controller.anyCardsInPlay({ faction: 'lannister', type: 'character', trait: ['Lord', 'Commander'] }),
+            match: this,
             effect: [
                 ability.effects.modifyStrength(3),
                 ability.effects.addKeyword('Assault')

--- a/server/game/cards/24-TSoW/SerAndreyDalt.js
+++ b/server/game/cards/24-TSoW/SerAndreyDalt.js
@@ -2,16 +2,9 @@ const DrawCard = require('../../drawcard.js');
 
 class SerAndreyDalt extends DrawCard {
     setupCardAbilities(ability) {
-        this.interrupt({
-            when: {
-                onDominanceDetermined: event => this.controller === event.winner
-            },
-            choosePlayer: () => true,
-            cost: ability.costs.discardFromShadows(),
-            message: '{player} uses {source} and discards {costs.discardFromShadows} from shadows to have {chosenPlayer} win dominance instead',
-            handler: context => {
-                context.event.winner = context.chosenPlayer;
-            }
+        this.persistentEffect({
+            targetController: 'opponent',
+            effect: ability.effects.cannotGainDominancePower()
         });
     }
 }

--- a/server/game/cards/24-TSoW/SerDavenLannister.js
+++ b/server/game/cards/24-TSoW/SerDavenLannister.js
@@ -2,12 +2,13 @@ const DrawCard = require('../../drawcard.js');
 const GameActions = require('../../GameActions/index.js');
 
 class SerDavenLannister extends DrawCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 onCardPowerGained: event => event.card === this
             },
             message: '{player} uses {source} to discard 1 card at random from each opponents hand',
+            limit: ability.limit.perRound(2),
             gameAction: GameActions.simultaneously(context => 
                 context.game.getOpponents(context.player).map(opponent => GameActions.discardAtRandom({ amount: 1, player: opponent }))
             ).then({

--- a/server/game/drawcard.js
+++ b/server/game/drawcard.js
@@ -23,8 +23,6 @@ class DrawCard extends BaseCard {
         this.inDanger = false;
         this.saved = false;
         this.challengeOptions = new ReferenceCountedSetProperty();
-        this.stealthLimit = 1;
-        this.pillageLimit = 1;
         this.minCost = 0;
         this.eventPlacementLocation = 'discard pile';
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -344,6 +344,7 @@ const Effects = {
             }
         };
     },
+    ignoresAssaultLocationCost: challengeOptionEffect('ignoresAssaultLocationCost'),
     addIcon: function(icon) {
         return {
             apply: function(card, context) {

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -327,20 +327,30 @@ const Effects = {
     addStealthLimit: function(value) {
         return {
             apply: function(card) {
-                card.stealthLimit += value;
+                card.raiseKeywordLimit('stealth', value);
             },
             unapply: function(card) {
-                card.stealthLimit -= value;
+                card.lowerKeywordLimit('stealth', value);
             }
         };
     },
     addPillageLimit: function(value) {
         return {
             apply: function(card) {
-                card.pillageLimit += value;
+                card.raiseKeywordLimit('pillage', value);
             },
             unapply: function(card) {
-                card.pillageLimit -= value;
+                card.lowerKeywordLimit('pillage', value);
+            }
+        };
+    },
+    addAssaultLimit: function(value) {
+        return {
+            apply: function(card) {
+                card.raiseKeywordLimit('assault', value);
+            },
+            unapply: function(card) {
+                card.lowerKeywordLimit('assault', value);
             }
         };
     },

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -1129,6 +1129,17 @@ const Effects = {
             }
         };
     },
+    cannotGainDominancePower: function() {
+        return {
+            targetType: 'player',
+            apply: function(player) {
+                player.flag.add('cannotGainDominancePower');
+            },
+            unapply: function(player) {
+                player.flag.remove('cannotGainDominancePower');
+            }
+        };
+    },
     canSelectAsFirstPlayer: function(condition) {
         return {
             targetType: 'player',

--- a/server/game/gamesteps/challenge/ChooseAssaultTargets.js
+++ b/server/game/gamesteps/challenge/ChooseAssaultTargets.js
@@ -18,10 +18,11 @@ class ChooseAssaultTargets extends BaseStep {
         if(this.assaultCharacters.length > 0 && !this.assaultTargetChosen) {
             let highestPrintedCost = Math.max(...this.assaultCharacters.map(character => character.getPrintedCost()));
             let characterWithHighestPrintedCost = this.assaultCharacters.find(character => character.getPrintedCost() === highestPrintedCost);
-            
-            let title = 'Select assault target for ' + characterWithHighestPrintedCost.name;
+            // Keyword modifier adjusts the number of locations that can be targeted using assault
+            let numTargets = 1 + characterWithHighestPrintedCost.getKeywordLimitModifier('assault');
+            let title = `Select ${numTargets === 1 ? 'assault target' : `up to ${numTargets} assault targets`} for ${characterWithHighestPrintedCost.name}`;
             this.game.promptForSelect(characterWithHighestPrintedCost.controller, {
-                numCards: 1,
+                numCards: numTargets,
                 activePromptTitle: title,
                 waitingPromptTitle: 'Waiting for opponent to choose assault target for ' + characterWithHighestPrintedCost.name,
                 cardCondition: card => this.canAssault(card, this.challenge, characterWithHighestPrintedCost),

--- a/server/game/gamesteps/challenge/ChooseAssaultTargets.js
+++ b/server/game/gamesteps/challenge/ChooseAssaultTargets.js
@@ -47,7 +47,7 @@ class ChooseAssaultTargets extends BaseStep {
             this.challenge.addAssaultChoice(character, target);
         }
 
-        this.game.addMessage('{0} has chosen {1} as the assault target for {2} and blanks it until the end of the challenge', this.challenge.attackingPlayer, targets, character);
+        this.game.addMessage(`{0} has chosen {1} as the assault ${targets.length > 1 ? 'targets' : 'target' } for {2} and blanks ${targets.length > 1 ? 'them' : 'it' } until the end of the challenge`, this.challenge.attackingPlayer, targets, character);
 
         this.assaultTargetChosen = true;
 

--- a/server/game/gamesteps/challenge/ChooseStealthTargets.js
+++ b/server/game/gamesteps/challenge/ChooseStealthTargets.js
@@ -42,8 +42,8 @@ class ChooseStealthTargets extends BaseStep {
         for(let target of targets) {
             this.challenge.addStealthChoice(character, target);
         }
-
-        this.game.addMessage('{0} has chosen {1} as the stealth target for {2}', this.challenge.attackingPlayer, targets, character);
+        
+        this.game.addMessage(`{0} has chosen {1} as the stealth ${targets.length > 1 ? 'targets' : 'target' } for {2}`, this.challenge.attackingPlayer, targets, character);
 
         return true;
     }

--- a/server/game/gamesteps/challenge/ChooseStealthTargets.js
+++ b/server/game/gamesteps/challenge/ChooseStealthTargets.js
@@ -15,10 +15,11 @@ class ChooseStealthTargets extends BaseStep {
     continue() {
         if(this.stealthCharacters.length > 0) {
             let character = this.stealthCharacters.shift();
-
-            let title = character.stealthLimit === 1 ? 'Select stealth target for ' + character.name : 'Select up to ' + character.stealthLimit + ' stealth targets for ' + character.name;
+            // Keyword modifier adjusts the number of characters that can be bypassed using stealth
+            let numTargets = 1 + character.getKeywordLimitModifier('stealth');
+            let title = `Select ${numTargets === 1 ? 'stealth target' : `up to ${numTargets} stealth targets`} for ${character.name}`;
             this.game.promptForSelect(character.controller, {
-                numCards: character.stealthLimit,
+                numCards: numTargets,
                 activePromptTitle: title,
                 waitingPromptTitle: 'Waiting for opponent to choose stealth target for ' + character.name,
                 cardCondition: card => this.canStealth(card, this.challenge, character),

--- a/server/game/gamesteps/dominancephase.js
+++ b/server/game/gamesteps/dominancephase.js
@@ -37,7 +37,7 @@ class DominancePhase extends Phase {
         if(dominanceWinner) {
             //save the winner of dominance on the game object in order to use this information in determining the winner of the game after the time limit has expired
             this.game.winnerOfDominanceInLastRound = dominanceWinner;
-            if(dominanceWinner.canGainFactionPower()) {
+            if(dominanceWinner.canGainFactionPower() && !dominanceWinner.hasFlag('cannotGainDominancePower')) {
                 this.game.addMessage('{0} wins dominance ({1} vs {2})', dominanceWinner, highestDominance, lowestDominance);
                 this.game.addPower(dominanceWinner, 1);
             } else {

--- a/server/game/pillagekeyword.js
+++ b/server/game/pillagekeyword.js
@@ -12,7 +12,9 @@ class PillageKeyword extends BaseAbility {
 
     executeHandler(context) {
         let {game, challenge, source} = context;
-        game.raiseEvent('onPillage', { source: source, numCards: source.pillageLimit }, event => {
+        // Keyword modifier adjusts the number of cards discarded for pillage
+        let amount = 1 + source.getKeywordLimitModifier('pillage');
+        game.raiseEvent('onPillage', { source: source, numCards: amount }, event => {
             challenge.loser.discardFromDraw(event.numCards, cards => {
                 game.addMessage('{0} discards {1} from the top of their deck due to Pillage from {2}', challenge.loser, cards, source);
             }, { isPillage: true, source: source });


### PR DESCRIPTION
### :dart: **Playtesting Website Update - v 24.6**

### :arrows_clockwise: **Reworked:**
- **One, Two, Three v1.1**: Approaching this card from a different angle, whilst trying to retain it's essence. Adjusted to be easier to trigger, but nerfed by making the return to hand a cost, and providing insight & character blank as the reward.*Note that we need to keep ability size in mind for this card, as it will struggle to fit neatly onto a card whilst doing so much.*
- **Ser Andrey Dalt v1.2**: Changing his ability to simply block opponents from gaining dominance power. *Note that this primarily came from concerns that the previous ability, although not distinctly overpowered, would greatly limit future design space for losing dominance, as it's hard to balance when a card ensures you almost always lose when you want to.*
- **King Robb's Bannermen v1.2**: Ability now simplified to double-assault when you control a :stark: ***King*** character.
- **The Crag v1.2**: A new approach to prevent initiating :intrigue:, and move that discard reward into winning :military:; we are aware this may feel underwhelminmg for the downside, and will look to tweak after testing if it proves true.
- **The Field of Fire v1.1**: Attempting to simplify this card's mechanics without removing it's essence. Now 2 cost, and simply non-terminally burns all non-***Dragon*** participants for each ***Dragon*** you have, with extra burn if they are an ***Army***. Also, changing from ~~Loyal~~ to Non-Loyal

### :arrow_double_up: **Updated:**
- **Dragonstone v1.1**: Removing the ***Westeros*** trait for the ***Dragonstone*** trait, and adding a semi-useful passive to raise the consistency of this card when return-to-shadow effects aren't present, by reducing your first event by 1.
- **Dagmer Cleftjaw v1.1**: Changing shadow cost from ~~Shadow (3)~~ to Shadow (4).
- **Ser Daven Lannister v1.2**: Limiting the ability to twice per round, and changing from ~~Non-Loyal~~ to Loyal.
- **Mace Tyrell v1.1**: Simply changing from ~~Loyal~~ to Non-Loyal.
- **Highgarden Sept v1.2**: Removing the ~~+1 Reserve~~, changing from ~~Non-Loyal~~ to Loyal, and altering the reaction to only trigger on ***The Seven*** cards.
- **King's Landing Mob v1.2**: Reapproaching the cost/passive to better reflect it's mechanical intention. Also, lowering STR from ~~3~~ to 2.
- **Former Champion v1.1**: Nerfing it's STR from ~~5~~ to 4. *Note that we also want to push testing this card with Shagwell/***Fool*** decks.*

### :wrench: **Bugfixed:**
- **Oxcross Survivors**: Fixed a bug that caused it to crash the game once it's condition was met.
- **Caggo Corpsekiller**: Fixed a bug that caused him to crash the game.

