### PR TITLE
Fixing simultaneous wording & actions

### DIFF
--- a/server/game/GameActions/AssaultkeywordAction.js
+++ b/server/game/GameActions/AssaultkeywordAction.js
@@ -31,12 +31,16 @@ class AssaultKeywordAction extends GameAction {
                 match: target,
                 effect: ability.effects.blankExcludingTraits
             }));
-            challenge.game.once('afterChallenge', event => {
-                if(event.challenge.winner === source.controller && target.allowGameAction('kneel')) {
-                    challenge.game.addMessage('{0} kneels {1} due to assault', source.controller, target);
-                    challenge.game.resolveGameAction(GameActions.kneelCard({ card: target, source: source, cause: 'assault' }));
-                }
-            });
+        });
+    }
+
+    setupSimultaneousKneel({ challenge }) {
+        challenge.game.once('afterChallenge', event => {
+            let successful = event.challenge.assaultData.filter(assaultChoice => event.challenge.winner === assaultChoice.source.controller && assaultChoice.target.allowGameAction('kneel'));
+            if(successful.length > 1) {
+                event.challenge.game.addMessage('{0} kneels {1} due to assault', event.challenge.winner, successful.map(assaultChoice => assaultChoice.target));
+                event.challenge.game.resolveGameAction(GameActions.simultaneously(successful.map(assaultChoice => GameActions.kneelCard({ card: assaultChoice.target, source: assaultChoice.source, cause: 'assault' }))));
+            }
         });
     }
 }

--- a/server/game/GameActions/InitiateChallenge.js
+++ b/server/game/GameActions/InitiateChallenge.js
@@ -21,6 +21,8 @@ class InitiateChallenge extends GameAction {
             
             challenge.stealthData.forEach(stealthChoice => event.thenAttachEvent(BypassByStealth.createEvent({ challenge, source: stealthChoice.source, target: stealthChoice.target })));
             challenge.assaultData.forEach(assaultChoice => event.thenAttachEvent(AssaultKeywordAction.createEvent({ challenge, source: assaultChoice.source, target: assaultChoice.target })));
+            // Grouping the kneel events for assault to ensure interrupts/reactions to multiple kneels are treated as simultaneous
+            AssaultKeywordAction.setupSimultaneousKneel({ challenge });
 
             event.thenExecute(event => {
                 // Reapply effects which rely on being within a challenge (eg. The Lord of the Crossing)

--- a/server/game/gamesteps/challenge/ChooseAssaultTargets.js
+++ b/server/game/gamesteps/challenge/ChooseAssaultTargets.js
@@ -47,7 +47,7 @@ class ChooseAssaultTargets extends BaseStep {
             this.challenge.addAssaultChoice(character, target);
         }
 
-        this.game.addMessage('{0} has chosen {1} as the assault target for {2} and blanks it until the end of the challenge', this.challenge.attackingPlayer, targets, character);
+        this.game.addMessage(`{0} has chosen {1} as the assault ${targets.length > 1 ? 'targets' : 'target' } for {2} and blanks ${targets.length > 1 ? 'them' : 'it' } until the end of the challenge`, this.challenge.attackingPlayer, targets, character);
 
         this.assaultTargetChosen = true;
 

--- a/server/game/gamesteps/challenge/ChooseStealthTargets.js
+++ b/server/game/gamesteps/challenge/ChooseStealthTargets.js
@@ -42,8 +42,8 @@ class ChooseStealthTargets extends BaseStep {
         for(let target of targets) {
             this.challenge.addStealthChoice(character, target);
         }
-
-        this.game.addMessage('{0} has chosen {1} as the stealth target for {2}', this.challenge.attackingPlayer, targets, character);
+        
+        this.game.addMessage(`{0} has chosen {1} as the stealth ${targets.length > 1 ? 'targets' : 'target' } for {2}`, this.challenge.attackingPlayer, targets, character);
 
         return true;
     }


### PR DESCRIPTION
Almost certain there is a better approach for this, but the intention is to ensure that each assaulted location is knelt **simultaneously**. This means effects that react to that kneeling (such as Defiance of Duskendale) correctly let you choose which to trigger on.