### PR TITLE
Additions & Improvements to Keyword Limits update

### DIFF
--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -22,7 +22,6 @@ class AbilityTarget {
         this.choosingPlayer = properties.choosingPlayer || 'current';
         this.name = name;
         this.properties = properties;
-        this.selector = CardSelector.for(properties);
         this.messages = properties.messages;
         this.ifAble = !!properties.ifAble;
         this.subTargets = properties.subTargets ? Object.entries(properties.subTargets).map(([name, properties]) => {
@@ -32,14 +31,17 @@ class AbilityTarget {
     }
 
     canResolve(context) {
+        const selector = CardSelector.for({ context, ...this.properties });
         const players = this.getChoosingPlayers(context);
         return this.ifAble || players.length > 0 && players.every(choosingPlayer => {
             context.choosingPlayer = choosingPlayer;
-            return this.selector.hasEnoughTargets(context);
+            return selector.hasEnoughTargets(context);
         }) && this.subTargets.every(subTarget => subTarget.canResolve(context));
     }
 
     buildPlayerSelection(context) {
+        // Creating the selector once the target is being selected for effects such as keywords with a changing target amount
+        this.selector = CardSelector.for({ context, ...this.properties });
         let eligibleCards = this.selector.getEligibleTargets(context);
         let subResults = this.subTargets.map(subTarget => subTarget.buildPlayerSelection(context));
         return new AbilityChoiceSelection({

--- a/server/game/CardSelector.js
+++ b/server/game/CardSelector.js
@@ -40,6 +40,8 @@ class CardSelector {
 
     static getDefaultedProperties(properties) {
         properties = Object.assign({}, defaultProperties, properties);
+        properties.numCards = typeof(properties.numCards) === 'function' ? properties.numCards(properties.context) : properties.numCards;
+
         if(properties.mode) {
             return properties;
         }

--- a/server/game/GameActions/AssaultkeywordAction.js
+++ b/server/game/GameActions/AssaultkeywordAction.js
@@ -1,5 +1,5 @@
 const GameAction = require('./GameAction');
-const GameActions = require('./index');
+const KneelCard = require('./KneelCard');
 
 /*
 Assault is a keyword ability.
@@ -31,16 +31,16 @@ class AssaultKeywordAction extends GameAction {
                 match: target,
                 effect: ability.effects.blankExcludingTraits
             }));
-        });
-    }
 
-    setupSimultaneousKneel({ challenge }) {
-        challenge.game.once('afterChallenge', event => {
-            let successful = event.challenge.assaultData.filter(assaultChoice => event.challenge.winner === assaultChoice.source.controller && assaultChoice.target.allowGameAction('kneel'));
-            if(successful.length > 1) {
-                event.challenge.game.addMessage('{0} kneels {1} due to assault', event.challenge.winner, successful.map(assaultChoice => assaultChoice.target));
-                event.challenge.game.resolveGameAction(GameActions.simultaneously(successful.map(assaultChoice => GameActions.kneelCard({ card: assaultChoice.target, source: assaultChoice.source, reason: 'assault' }))));
-            }
+            challenge.game.once('afterChallenge', event => {
+                const props = { card: target, source: source, reason: 'assault' };
+                if(challenge.winner === source.controller 
+                    && challenge.winner.anyCardsInPlay(card => card.isAttacking() && card.hasKeyword('assault'))
+                    && KneelCard.allow(props)) {
+                    event.thenAttachEvent(KneelCard.createEvent(props)
+                        .thenExecute(() => challenge.game.addMessage('{0} kneels {1} due to assault', challenge.winner, target)));
+                }
+            });
         });
     }
 }

--- a/server/game/GameActions/InitiateChallenge.js
+++ b/server/game/GameActions/InitiateChallenge.js
@@ -21,8 +21,6 @@ class InitiateChallenge extends GameAction {
             
             challenge.stealthData.forEach(stealthChoice => event.thenAttachEvent(BypassByStealth.createEvent({ challenge, source: stealthChoice.source, target: stealthChoice.target })));
             challenge.assaultData.forEach(assaultChoice => event.thenAttachEvent(AssaultKeywordAction.createEvent({ challenge, source: assaultChoice.source, target: assaultChoice.target })));
-            // Grouping the kneel events for assault to ensure interrupts/reactions to multiple kneels are treated as simultaneous
-            AssaultKeywordAction.setupSimultaneousKneel({ challenge });
 
             event.thenExecute(event => {
                 // Reapply effects which rely on being within a challenge (eg. The Lord of the Crossing)

--- a/server/game/gamesteps/selectcardprompt.js
+++ b/server/game/gamesteps/selectcardprompt.js
@@ -69,6 +69,7 @@ class SelectCardPrompt extends UiPrompt {
                 this.cannotUnselectMustSelect = true;
             }
         }
+        this.activePromptTitleFunc = typeof(properties.activePromptTitle) === 'function' ? properties.activePromptTitle : () => properties.activePromptTitle;
         this.revealTargets = properties.revealTargets;
         this.revealFunc = null;
         this.savePreviouslySelectedCards();
@@ -123,7 +124,7 @@ class SelectCardPrompt extends UiPrompt {
         return {
             selectCard: true,
             selectOrder: this.properties.ordered,
-            menuTitle: this.properties.activePromptTitle || this.selector.defaultActivePromptTitle(),
+            menuTitle: this.activePromptTitleFunc(this.context) || this.selector.defaultActivePromptTitle(),
             buttons: this.properties.additionalButtons.concat([
                 { text: this.properties.doneButtonText || 'Done', arg: 'done' }
             ]),

--- a/server/game/intimidatekeyword.js
+++ b/server/game/intimidatekeyword.js
@@ -5,7 +5,8 @@ class IntimidateKeyword extends BaseAbility {
     constructor() {
         super({
             target: {
-                activePromptTitle: 'Select a character to intimidate',
+                activePromptTitle: context => this.getTitle(context.source),
+                numCards: context => this.getAmount(context.source),
                 cardCondition: (card, context) => this.canIntimidate(card, context.challenge.strengthDifference, context.challenge),
                 gameAction: 'kneel'
             },
@@ -19,6 +20,15 @@ class IntimidateKeyword extends BaseAbility {
             }
         });
         this.title = 'Intimidate';
+    }
+
+    getTitle(source) {
+        var numTargets = this.getAmount(source);
+        return `Select ${numTargets === 1 ? 'a character' : `up to ${numTargets} characters`} to intimidate`;
+    }
+
+    getAmount(source) {
+        return 1 + source.getKeywordTriggerModifier(this.title);
     }
 
     canIntimidate(card, strength, challenge) {

--- a/test/server/integration/assault.spec.js
+++ b/test/server/integration/assault.spec.js
@@ -1,0 +1,223 @@
+describe('assault', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('greyjoy', [
+                'Trading with the Pentoshi',
+                'The Iron Fleet', 'Dagmer Cleftjaw (TS)', 'Thenns', 'Foamdrinker'
+            ]);
+            const deck2 = this.buildDeck('thenightswatch', [
+                'Trading with the Pentoshi',
+                'Great Ranging', 'Old Forest Hunter', 'The Wall (Core)', 'Queenscrown', 'Nightmares', 'Fist of the First Men'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.ironFleet = this.player1.findCardByName('The Iron Fleet', 'hand');
+            this.dagmer = this.player1.findCardByName('Dagmer Cleftjaw', 'hand');
+            this.thenns = this.player1.findCardByName('Thenns', 'hand');
+            this.foamdrinker = this.player1.findCardByName('Foamdrinker', 'hand');
+            this.greatRanging = this.player2.findCardByName('Great Ranging', 'hand');
+            this.hunter = this.player2.findCardByName('Old Forest Hunter', 'hand');
+            this.wall = this.player2.findCardByName('The Wall', 'hand');
+            this.nightmares = this.player2.findCardByName('Nightmares', 'hand');
+            this.fist = this.player2.findCardByName('Fist of the First Men', 'hand');
+
+            this.player1.clickCard(this.ironFleet);
+            this.player2.clickCard(this.wall);
+            this.player2.clickCard(this.hunter);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+
+            // Resolve plot order
+            this.selectPlotOrder(this.player1);
+
+            this.player1.clickCard(this.dagmer);
+            this.player1.clickCard(this.thenns);
+            this.player1.clickPrompt('Done');
+
+            this.player2.clickCard(this.greatRanging);
+            this.player2.clickCard(this.fist);
+            this.player2.clickPrompt('Done');
+        });
+
+        describe('when a lower costing character with assault is declared as an attacker', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.thenns);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should prompt to only choose a location with a lower printed cost', function() {
+                expect(this.player1).toHavePrompt('Select assault target for Thenns');
+                expect(this.player1).toAllowSelect(this.fist);
+                expect(this.player1).not.toAllowSelect(this.wall);
+            });
+        });
+
+        describe('when a single attacking character assaults a location', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.ironFleet);
+                this.player1.clickPrompt('Done');
+                
+                this.player1.clickCard(this.wall);
+
+                // Pass Iron Fleet prompt
+                this.player1.clickPrompt('Pass');
+            });
+            
+            it('should immediately blank that location', function() {
+                // With The Wall blanked, it should be 7 STR + 1 STR from Fist of the First Men
+                expect(this.greatRanging.getStrength()).toBe(8);
+            });
+
+            describe('and the attacker loses the challenge', function() {
+                beforeEach(function() {
+                    this.skipActionWindow();
+
+                    // Attacker loses with 8 STR vs 10 STR
+                    this.player2.clickCard(this.greatRanging);
+                    this.player2.clickCard(this.hunter);
+                    this.player2.clickPrompt('Done');
+
+                    this.skipActionWindow();
+                });
+
+                it('should not kneel the location', function() {
+                    expect(this.wall.kneeled).toBe(false);
+                });
+                
+                it('should un-blank the location once the challenge is fully resolved', function() {
+                    expect(this.greatRanging.getStrength()).toBe(9);
+                });
+            });
+
+            describe('and the attacker wins the challenge', function() {
+                beforeEach(function() {
+                    this.skipActionWindow();
+
+                    // Attacker wins with 8 STR vs 2 STR
+                    this.player2.clickCard(this.hunter);
+                    this.player2.clickPrompt('Done');
+                    
+                    this.skipActionWindow();
+                });
+
+                it('should immediately kneel the location', function() {
+                    expect(this.wall.kneeled).toBe(true);
+                });
+
+                it('should un-blank the location once the challenge is fully resolved', function() {
+                    // With The Wall blanked, it should be 7 STR + 1 STR from Fist of the First Men
+                    expect(this.greatRanging.getStrength()).toBe(8);
+
+                    this.player1.clickPrompt('Apply Claim');
+                    this.player2.clickCard(this.hunter);
+
+                    expect(this.greatRanging.getStrength()).toBe(9);
+                });
+            });
+        });
+
+        describe('when multiple attacking characters have assault', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.ironFleet);
+                this.player1.clickCard(this.thenns);
+                this.player1.clickPrompt('Done');
+            });
+
+            it('should prompt to choose a location with a lower printed cost to the highest cost attacker with assault', function() {
+                expect(this.player1).toHavePrompt('Select assault target for The Iron Fleet');
+                expect(this.player1).toAllowSelect(this.fist);
+                expect(this.player1).toAllowSelect(this.wall);
+            });
+
+            describe('and the initial assaulting character loses assault', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.wall);
+                    
+                    // Pass Iron Fleet prompt
+                    this.player1.clickPrompt('Pass');
+
+                    this.player1.clickPrompt('Pass');
+
+                    // Iron Fleet losing assault
+                    this.player2.clickCard('Nightmares');
+                    this.player2.clickCard(this.ironFleet);
+
+                    this.skipActionWindow();
+                });
+
+                it('should continue blanking the location', function() {
+                    expect(this.greatRanging.getStrength()).toBe(8);
+                });
+
+                it('should immediately kneel the location after winning the challenge', function() {
+                    // Attacker wins with 8 STR vs 2 STR
+                    this.player2.clickCard(this.hunter);
+                    this.player2.clickPrompt('Done');
+                    
+                    this.skipActionWindow();
+                    
+                    expect(this.wall.kneeled).toBe(true);
+                });
+            });
+        });
+
+        describe('when an attacking character assaults a location, but during the challenge it loses assault', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.ironFleet);
+                this.player1.clickCard(this.dagmer);
+                this.player1.clickPrompt('Done');
+                
+                this.player1.clickCard(this.wall);
+
+                // Pass Iron Fleet prompt
+                this.player1.clickPrompt('Pass');
+
+                this.player1.clickPrompt('Pass');
+                
+                // Iron Fleet losing assault
+                this.player2.clickCard('Nightmares');
+                this.player2.clickCard(this.ironFleet);
+            });
+
+            it('should not kneel the location after winning the challenge', function() {
+                this.skipActionWindow();
+
+                // Attacker wins with 8 STR vs 2 STR
+                this.player2.clickCard(this.hunter);
+                this.player2.clickPrompt('Done');
+                
+                this.skipActionWindow();
+                
+                expect(this.wall.kneeled).toBe(false);
+            });
+
+            describe('and another attacker gains assault', function() {
+                beforeEach(function() {
+                    // Dagmer gaining assault
+                    this.player1.dragCard(this.foamdrinker, 'play area');
+
+                    this.skipActionWindow();
+                });
+                
+                it('should immediately kneel the location after winning the challenge', function() {
+                    // Attacker wins with 8 STR vs 2 STR
+                    this.player2.clickCard(this.hunter);
+                    this.player2.clickPrompt('Done');
+                    
+                    this.skipActionWindow();
+                    
+                    expect(this.wall.kneeled).toBe(true);
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Altering `AbilityTarget.js` to build it's `CardSelector` once it's ability is being resolved (and thus targets being selected); this allows for more dynamic selections based on when that ability is being triggered for abilities which are built once, such as keywords. The simplest example would be if a character could ever intimidate more than 1 target.

This is part of an update to "limitize" all keywords where appropriate, so any "raise the number of targets for X keyword" abilities can be implemented flawlessly & easily.

Also added a proper test for assault, and fixed various issues around it being incorrectly handled (both bugs, and logic). Also changed the kneel to be added within the single assault blank event, but to still kneel simultaneously with the `afterChallenge` event by being a child event.

Close: #344 