### PR TITLE
Playtesting Update - v 24.8

### DIFF
--- a/server/game/cards/24-TSoW/OldtownCityWatch.js
+++ b/server/game/cards/24-TSoW/OldtownCityWatch.js
@@ -1,18 +1,14 @@
 const DrawCard = require('../../drawcard.js');
+const GameActions = require('../../GameActions/index.js');
 
 class OldtownCityWatch extends DrawCard {
     setupCardAbilities() {
         this.reaction({
             when: {
-                onCardRevealed: event => ['hand', 'draw deck', 'shadows'].includes(event.card.location) && event.card.controller === this.controller
+                onCardEntersPlay: event => event.card === this
             },
-            message: '{player} uses {source} to ensure that {source} cannot be stealth until the end of the phase',
-            handler: () => {
-                this.untilEndOfPhase(ability => ({
-                    match: this,
-                    effect: ability.effects.cannotBeBypassedByStealth()
-                }));
-            }
+            message: '{player} uses {source} to reveal the top card of each players deck',
+            gameAction: GameActions.revealCards(context => ({ cards: context.game.getPlayers().map(player => player.drawDeck[0]) }))
         });
     }
 }

--- a/server/game/cards/24-TSoW/OneTwoThree.js
+++ b/server/game/cards/24-TSoW/OneTwoThree.js
@@ -5,44 +5,48 @@ class OneTwoThree extends DrawCard {
     setupCardAbilities(ability) {
         this.reaction({
             when: {
-                afterChallenge: event => event.challenge.isMatch({ winner: this.controller, attackingPlayer: this.controller, challengeType: 'intrigue' })
+                afterChallenge: event => event.challenge.isMatch({
+                    winner: this.controller,
+                    challengeType: 'intrigue',
+                    by5: true
+                })
             },
-            cost: ability.costs.returnToHand(card => card.getType() === 'character' && card.location === 'play area'),
-            // TODO: Technically the target should be choosing 2 characters, then deciding which does what; implement properly on release.
+            // TODO: Technically the target should be choosing 3 characters, then deciding which does what. Implement properly later.
             targets: {
+                hand: {
+                    activePromptTitle: 'Select character to return to hand',
+                    cardCondition: { type: 'character', controller: 'current' }
+                },
+                shadows: {
+                    activePromptTitle: 'Select character to place into shadows',
+                    cardCondition: { type: 'character', controller: 'current' }
+                },
                 insight: {
                     activePromptTitle: 'Select character to gain insight',
-                    cardCondition: { type: 'character', location: 'play area' }
-                },
-                blank: {
-                    activePromptTitle: 'Select character to blank',
-                    cardCondition: { type: 'character', location: 'play area'}
+                    cardCondition: { type: 'character', controller: 'current' }
                 }
             },
+            max: ability.limit.perPhase(1),
             message: {
-                format: '{player} plays {source} and returns {costs.returnToHand} to their hand to choose {targets}',
+                format: '{player} plays {source} to choose {targets}',
                 args: { targets: context => context.targets.getTargets() }
             },
             handler: context => {
                 this.game.resolveGameAction(
                     GameActions.simultaneously([
+                        GameActions.returnCardToHand(context => ({ card: context.targets.hand })),
+                        GameActions.putIntoShadows(context => ({ card: context.targets.shadows })),
                         GameActions.genericHandler(context => {
                             this.untilEndOfPhase(ability => ({
                                 match: context.targets.insight,
                                 effect: ability.effects.addKeyword('insight')
                             }));
-                        }),
-                        GameActions.genericHandler(context => {
-                            this.untilEndOfPhase(ability => ({
-                                match: context.targets.blank,
-                                effect: ability.effects.blankExcludingTraits
-                            }));
                         })
                     ])
                     , context);
                     
-                this.game.addMessage('{1} gains insight and {2}\'s text box is treated as if it were blank (except for Traits) until the end of the phase',
-                    context.targets.insight, context.targets.blank);
+                this.game.addMessage('{0} returns {1} to it\'s owners hand, places {2} into shadows and has {3} gain insight until the end of the phase',
+                    this.controller, context.targets.hand, context.targets.shadows, context.targets.insight);
             }
         });
     }


### PR DESCRIPTION
## :dart: **Playtesting Update - v 24.8**

[Download Print & Play PDF (All Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_8_all.pdf)
[Download Print & Play PDF (Changed Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_8_changed.pdf)

 ### :arrows_clockwise: Reworks:
[➥ **One, Two, Three (v1.2)**:](https://hcti.io/v1/image/333fab69-cd5c-4943-b0e1-65c53124b467)
Reworked to a similar iteration to the initial version, however it now only chooses your own characters. Cost also lowered from ~~3~~ to 2. This will now fit more into :lannister: shadow decks.

[➥ **Oldtown City Watch (v1.3)**:](https://hcti.io/v1/image/0308fab6-f267-4a96-a4a1-fb168d919796)
Raised STR from ~~2~~ to 3, and reworked ability to reveal the top cards of all decks when entering play. Also adding the ***House Hightower*** trait for potential synergy with We Light the Way (and any future hightower combos).

---
*Applied on 27/03/2023 12:45AM GMT*