### PR TITLE
Playtesting Update - v 24.9

### DIFF
--- a/server/game/cards/24-TSoW/KingsLandingMob.js
+++ b/server/game/cards/24-TSoW/KingsLandingMob.js
@@ -7,12 +7,9 @@ class KingsLandingMob extends DrawCard {
             when: {
                 onCardKneeled: event => event.reason === 'assault'
             },
-            cost: [
-                ability.costs.killSelf(),
-                ability.costs.sacrifice(card => card.getType() === 'location')
-            ],
+            cost: ability.costs.killSelf(),
             message: {
-                format: '{player} kills {costs.kill} and sacrifices {costs.sacrifice} to discard {assaulted} from play',
+                format: '{player} kills {costs.kill} to discard {assaulted} from play',
                 args: { assaulted: context => context.event.card }
             },
             gameAction: GameActions.discardCard(context => ({ card: context.event.card }))

--- a/server/game/cards/24-TSoW/MaceTyrell.js
+++ b/server/game/cards/24-TSoW/MaceTyrell.js
@@ -11,7 +11,8 @@ class MaceTyrell extends DrawCard {
                 ability.costs.removeFromChallenge(card => card.hasTrait('Army') && card.isParticipating())
             ],
             target: {
-                cardCondition: (card, context) => card.isParticipating() && (!context.costs.stand || context.costs.stand !== card)
+                cardCondition: (card, context) => card.isParticipating()
+                    && (!context.costs.stand || (card !== context.costs.stand && card.getPrintedCost() <= context.costs.stand.getPrintedCost()))
             },
             limit: ability.limit.perPhase(1),
             message: '{player} uses {source}, stands and removes {cost.stand} from the challenge to stand and remove {target} from the challenge',

--- a/server/game/cards/24-TSoW/TheCrag.js
+++ b/server/game/cards/24-TSoW/TheCrag.js
@@ -9,18 +9,18 @@ class TheCrag extends DrawCard {
         });
         this.reaction({
             when: {
-                afterChallenge: event => event.challenge.isMatch({ challengeType: 'military', winner: this.controller, by5: true })
+                afterChallenge: event => event.challenge.isMatch({ challengeType: 'military', winner: this.controller, attackingPlayer: this.controller })
             },
             message: {
-                format: '{player} uses {source} to discard {amount} cards at random from {loser}\'s hand',
-                args: { amount: context => this.getAmountForDiscard(context), loser: context => context.event.challenge.loser }
+                format: '{player} uses {source} to gain {amount} power for their faction',
+                args: { amount: context => this.getAmount(context) }
             },
-            gameAction: GameActions.discardAtRandom(context => ({ player: context.event.challenge.loser, amount: this.getAmountForDiscard(context) }))
+            gameAction: GameActions.gainPower(context => ({ card: context.player.faction, amount: this.getAmount(context) }))
         });
     }
 
-    getAmountForDiscard(context) {
-        return context.player.anyCardsInPlay(card => card.name === 'Robb Stark') ? 2 : 1;
+    getAmount(context) {
+        return context.player.anyCardsInPlay(card => card.isFaction('stark') && card.hasTrait('King')) ? 2 : 1;
     }
 }
 

--- a/server/game/cards/24-TSoW/TheShadowTower.js
+++ b/server/game/cards/24-TSoW/TheShadowTower.js
@@ -9,6 +9,7 @@ class TheShadowTower extends DrawCard {
         });
         this.action({
             title: 'Reveal card in shadows',
+            phase: 'challenge',
             cost: ability.costs.kneelSelf(),
             target: {
                 activePromptTitle: 'Select a card',


### PR DESCRIPTION
## :dart: **Playtesting Website Update - v 24.9**

[Download Print & Play PDF (All Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_9_all.pdf)
[Download Print & Play PDF (Changed Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_9_changed.pdf)

### :arrows_clockwise: Reworked:
[➥ **The Field of Fire v1.2**:](https://hcti.io/v1/image/e48d59eb-a916-411b-8d7b-9947eb1446bc)
Reworked to apply minor burn to all targets in the challenges phase, which synergizes well with the 7 cost dragons; and is terminal for ***Army***'s.

### :arrow_double_up: Updated:
[➥ **The Shadow Tower v1.2**:](https://hcti.io/v1/image/3f4bd4d6-e0c8-44d3-903b-4d31b2b3f41a)
Changed to **Challenges Action**.
[➥ **The Crag v1.3**:](https://hcti.io/v1/image/d25473fb-0f6e-4f4f-804c-c9e504e5dc33)
Changing reaction to push for power gain rather than hand discard in order to closer match the downside of not being able to initiate INT challenges.
[➥ **Mace Tyrell v1.3**:](https://hcti.io/v1/image/8ff5ef4e-d401-4a2d-a339-65f647af3c92)
Target now needs to have a printed cost equal to or lower than the ***Army*** that was removed.
[➥ **King's Landing Mob v1.4**:](https://hcti.io/v1/image/6648dd72-2c36-45d0-b57b-642092c65c91)
Removing the sacrifice location cost.

---
*Applied on 03/04/2023 4:30AM GMT*