### PR TITLE
Playtesting Update - v 24.10

### DIFF
--- a/server/game/cards/24-TSoW/BattleOfTheCamps.js
+++ b/server/game/cards/24-TSoW/BattleOfTheCamps.js
@@ -10,12 +10,32 @@ class BattleOfTheCamps extends PlotCard {
             target: {
                 cardCondition: { type: 'character', location: 'play area', conditon: (card, context) => card.controller === context.event.challenge.loser }
             },
+            message: {
+                format: '{player} uses {source} to {actions} {target}',
+                args: { actions: context => !context.target.hasTrait('Army') ? 'kneel' : 'kneel or kill' }
+            },
             handler: context => {
-                this.game.resolveGameAction(GameActions.ifCondition({
-                    condition: context => context.target.hasTrait('Army'),
-                    thenAction: GameActions.kill(context => ({ card: context.target })),
-                    elseAction: GameActions.kneelCard(context => ({ card: context.target }))
-                }), context);
+                this.game.resolveGameAction(
+                    GameActions.ifCondition({
+                        condition: context => !context.target.hasTrait('Army'),
+                        thenAction: {
+                            gameAction: GameActions.kneelCard(context => ({ card: context.target }))
+                        },
+                        elseAction: GameActions.choose({
+                            title: context => `Kill ${context.target.name} instead?`,
+                            choices: {
+                                'Kill': {
+                                    message: '{player} chooses to kill {target}',
+                                    gameAction: GameActions.kill(context => ({ card: context.target }))
+                                },
+                                'Kneel': {
+                                    message: '{player} chooses to kneel {target}',
+                                    gameAction: GameActions.kneelCard(context => ({ card: context.target }))
+                                }
+                            }
+                        })
+                    })
+                    , context);
             }
         });
     }

--- a/server/game/cards/24-TSoW/Hero.js
+++ b/server/game/cards/24-TSoW/Hero.js
@@ -12,7 +12,7 @@ class Hero extends DrawCard {
             },
             target: {
                 type: 'select',
-                cardCondition: { type: 'character', trait: 'Army' }
+                cardCondition: { or: [{type: 'character', trait: 'Army'}, { name: 'Grey Worm' }] }
             },
             message: '{player} uses {source} to stand {target}',
             handler: context => {

--- a/server/game/cards/24-TSoW/SalladhorSaansLyseni.js
+++ b/server/game/cards/24-TSoW/SalladhorSaansLyseni.js
@@ -5,20 +5,23 @@ class SalladhorSaansLyseni extends DrawCard {
     setupCardAbilities(ability) {
         this.interrupt({
             when: {
-                onCardKneeled: event => event.card.getType() === 'location' && event.card.controller !== this.controller && event.card.controller.faction.power > 0 // TODO: Clean up kneeling to always identify if it is a card effect or not (eg. setting a cause where appropriate)
+                afterChallenge: event => event.challenge.winner === this.controller && this.isAttacking()
             },
-            target: {
-                cardCondition: { type: 'character', location: 'play area' }
-            },
-            limit: ability.limit.perRound(1),
+            limit: ability.limit.perPhase(1),
             message: {
-                format: '{player} uses {source} to move 1 power from {controller}\'s faction card to {target}',
-                args: { controller: context => context.event.card.controller }
+                format: '{player} uses {source} to have it gain {amount} power',
+                args: { amount: context => this.getAmount(context) }
             },
-            handler: context => {
-                this.game.resolveGameAction(GameActions.movePower(context => ({ from: context.event.card.controller.faction, to: context.target, amount: 1 })), context);
-            }
+            gameAction: GameActions.gainPower(context => ({
+                card: this,
+                amount: this.getAmount(context)
+            }))
         });
+    }
+
+    getAmount(context) {
+        let numCards = context.challenge.loser.getNumberOfCardsInPlay({ type: 'location', location: 'play area', kneeled: true });
+        return Math.floor(numCards / 2);
     }
 }
 

--- a/server/game/cards/24-TSoW/TheTrident.js
+++ b/server/game/cards/24-TSoW/TheTrident.js
@@ -11,7 +11,7 @@ class TheTrident extends DrawCard {
                 afterChallenge: event => event.challenge.winner === this.controller && event.challenge.attackingPlayer === this.controller
             },
             message: {
-                format: '{player} is forced to give control of {source} to {loser}, or sacrifice another location they own',
+                format: '{player} is forced to give control of {source} to {loser}, or sacrifice another neutral location',
                 args: { loser: context => context.event.challenge.loser }
             },
             gameAction: GameActions.choose({
@@ -27,7 +27,7 @@ class TheTrident extends DrawCard {
                         gameAction: GameActions.genericHandler(context => {
                             this.game.promptForSelect(context.player, {
                                 activePromptTitle: 'Select a location',
-                                cardCondition: card => card.getType() === 'location' && card.location === 'play area' && card.owner === context.player && card !== context.source,
+                                cardCondition: card => card.getType() === 'location' && card.location === 'play area' && card.isFaction('neutral') && card !== context.source,
                                 gameAction: 'sacrifice',
                                 onSelect: (player, card) => {
                                     this.game.addMessage('{0} chooses to sacrifice {1}', player, card);


### PR DESCRIPTION
:dart: **Playtesting Website Update - v 24.10**
---

[Download Print & Play PDF (All Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_10_all.pdf)
[Download Print & Play PDF (Changed Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_10_changed.pdf)

### :arrows_clockwise: **Reworked:**
[➥ **Salladhor Saan's Lyseni v2.2**:](https://hcti.io/v1/image/c42e468d-b6c6-48be-adc7-84e07d9d95f2)<br>Slightly reworked to allow for some counterplay, whilst continuing to act as a reward for kneeling opponents locations; gains power for every 2 knelt location after winning.

### :arrow_double_up: **Updated:**
[➥ **Hero v1.3**:](https://hcti.io/v1/image/fd452b68-bbd4-4ec2-a4f6-069b910b7587)<br>Can now stand either an ***Army*** character, or Grey Worm.
[➥ **The Trident v1.3**:](https://hcti.io/v1/image/b0ba309b-d0b7-4505-87c2-28b830038d14)<br>Sacrificed location must now be neutral (and you control, not own). Although we are aware this may make this location much harder to play, we already have future plans for it's support, so undershooting here is acceptable.
[➥ **Battle of the Camps v1.3**:](https://hcti.io/v1/image/787f4840-e64d-4a4f-acc2-df64847ab642)<br>Raised initiative from ~~6~~ to 7, and making the ***Army*** kill an option, rather than mandatory.

---
Closes #372, Closes #373, Closes #374, Closes #375

_Last Updated on Thu Apr 06 2023 02:12:14 GMT+0000 (Coordinated Universal Time)_