### PR TITLE
Playtesting Update - v 24.11

### DIFF
--- a/server/game/GameActions/ChooseGameAction.js
+++ b/server/game/GameActions/ChooseGameAction.js
@@ -32,7 +32,7 @@ class ChooseGameAction extends GameAction {
         const choosingPlayer = this.playerFunc(context);
         let tempContext = { ...context, choosingPlayer };
         const choices = this.createChoices(this.choicesFunc(tempContext));
-        const validChoices = choices.filter(choice => choice.condition(tempContext) && choice.gameAction.allow(tempContext));
+        const validChoices = choices.filter(choice => choice.condition(tempContext));
         return validChoices.length > 0;
     }
 

--- a/server/game/PlayActions/MarshalIntoShadowsAction.js
+++ b/server/game/PlayActions/MarshalIntoShadowsAction.js
@@ -38,7 +38,7 @@ class MarshalIntoShadowsAction extends BaseAbility {
             type: 'shadows'
         };
         context.game.raiseEvent('onCardMarshalled', params, () => {
-            context.player.putIntoShadows(context.source, 'marshal');
+            context.player.putIntoShadows(context.source);
             context.game.addMessage(this.getMessageFormat(params), context.player, params.originalLocation, params.originalParent, context.costs.gold);
         });
     }

--- a/server/game/PlayActions/MarshalIntoShadowsAction.js
+++ b/server/game/PlayActions/MarshalIntoShadowsAction.js
@@ -38,7 +38,7 @@ class MarshalIntoShadowsAction extends BaseAbility {
             type: 'shadows'
         };
         context.game.raiseEvent('onCardMarshalled', params, () => {
-            context.player.putIntoShadows(context.source);
+            context.player.putIntoShadows(context.source, 'marshal');
             context.game.addMessage(this.getMessageFormat(params), context.player, params.originalLocation, params.originalParent, context.costs.gold);
         });
     }

--- a/server/game/cards/24-TSoW/BattleOfTheCamps.js
+++ b/server/game/cards/24-TSoW/BattleOfTheCamps.js
@@ -2,7 +2,7 @@ const GameActions = require('../../GameActions');
 const PlotCard = require('../../plotcard');
 
 class BattleOfTheCamps extends PlotCard {
-    setupCardAbilities() {
+    setupCardAbilities(ability) {
         this.reaction({
             when: {
                 afterChallenge: event => event.challenge.challengeType === 'military' && event.challenge.attackingPlayer === this.controller
@@ -14,6 +14,7 @@ class BattleOfTheCamps extends PlotCard {
                 format: '{player} uses {source} to {actions} {target}',
                 args: { actions: context => !context.target.hasTrait('Army') ? 'kneel' : 'kneel or kill' }
             },
+            limit: ability.limit.perPhase(1),
             handler: context => {
                 this.game.resolveGameAction(
                     GameActions.ifCondition({

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -1,22 +1,30 @@
 const DrawCard = require('../../drawcard.js');
-const GameActions = require('../../GameActions');
 
 class Dragonstone extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            targetController: 'current',
-            effect: ability.effects.reduceFirstPlayedCardCostEachRound(1, card => card.getType() === 'event')
+            match: this,
+            effect: ability.effects.optionalStandDuringStanding()
         });
         this.reaction({
             when: {
-                onCardPutIntoShadows: () => true
+                onCardPutIntoShadows: event => event.reason === 'ability'
             },
             message: {
-                format: '{player} returns {source} to shadows to discard {card}',
+                format: '{player} kneels {source} and prevents {card} from coming out of shadows until {source} stands or leaves play',
                 args: { card: context => context.event.card }
             },
-            cost: ability.costs.putSelfIntoShadows(),
-            gameAction: GameActions.discardCard(context => ({ card: context.event.card, source: this }))
+            cost: ability.costs.kneelSelf(),
+            handler: context => {
+                this.lastingEffect(ability => ({
+                    until: {
+                        onCardStood: event => event.card === this,
+                        onCardLeftPlay: event => event.card === this,
+                        onCardMoved: event => event.card === context.event.card
+                    },
+                    effect: ability.effects.cannotBringOutOfShadows(card => card === context.event.card)
+                }));
+            }
         });
     }
 }

--- a/server/game/cards/24-TSoW/Dragonstone.js
+++ b/server/game/cards/24-TSoW/Dragonstone.js
@@ -8,7 +8,7 @@ class Dragonstone extends DrawCard {
         });
         this.reaction({
             when: {
-                onCardPutIntoShadows: event => event.reason === 'ability'
+                onCardPutIntoShadows: () => true // TODO: Prevent reacting to marshalling into shadows
             },
             message: {
                 format: '{player} kneels {source} and prevents {card} from coming out of shadows until {source} stands or leaves play',

--- a/server/game/cards/24-TSoW/HighgardenSept.js
+++ b/server/game/cards/24-TSoW/HighgardenSept.js
@@ -6,7 +6,7 @@ class HighgardenSept extends DrawCard {
         this.persistentEffect({
             condition: () => this.controller.hand.length >= 7,
             targetController: 'any',
-            effect: ability.effects.cannotPutIntoPlay((card, playingType) => card.getType() !== 'event' && !card.hasTrait('The Seven') && playingType !== 'marshal')
+            effect: ability.effects.cannotPutIntoPlay((card, playingType) => card.getType() === 'character' && !card.hasTrait('The Seven') && playingType !== 'marshal')
         });
         this.reaction({
             when: {

--- a/server/game/cards/24-TSoW/SerDavenLannister.js
+++ b/server/game/cards/24-TSoW/SerDavenLannister.js
@@ -7,17 +7,38 @@ class SerDavenLannister extends DrawCard {
             when: {
                 onCardPowerGained: event => event.card === this
             },
-            message: '{player} uses {source} to discard 1 card at random from each opponents hand',
+            message: '{player} uses {source} to have each opponent choose and discard 1 card from their hand',
             limit: ability.limit.perRound(2),
             gameAction: GameActions.simultaneously(context => 
-                context.game.getOpponents(context.player).map(opponent => GameActions.discardAtRandom({ amount: 1, player: opponent }))
+                context.game.getOpponents(context.player).map(opponent => GameActions.genericHandler(context => {
+                    this.game.promptForSelect(opponent, {
+                        source: this,
+                        activePrompt: 'Select a card',
+                        cardCondition: card => card.controller === opponent && card.location === 'hand',
+                        onSelect: (player, card) => this.onCardSelected(context, player, card),
+                        onCancel: player => this.onCancel(player)
+                    });
+                }))
             ).then({
                 condition: context => context.game.getOpponents(context.player).every(opponent => opponent.hand.length < context.player.hand.length),
                 message: 'Then, {player} draws 1 card',
                 gameAction: GameActions.drawCards(context => ({ amount: 1, player: context.player }))
             })
-            
         });
+    }
+
+    onCardSelected(context, player, card) {
+        this.game.addMessage('{0} discards {1} from their hand', player, card);
+        context.game.resolveGameAction(GameActions.discardCard({ card }), context);
+
+        return true;
+    }
+
+    onCancel(player) {
+        this.game.addAlert('danger', '{0} did not select a card to discard for {1}',
+            player, this);
+
+        return true;
     }
 }
 

--- a/server/game/cards/24-TSoW/TheBastardsBoys.js
+++ b/server/game/cards/24-TSoW/TheBastardsBoys.js
@@ -7,7 +7,7 @@ class TheBastardsBoys extends DrawCard {
             title: 'Sacrifice to put character into play',
             phase: 'challenge',
             target: {
-                cardCondition: { location: 'hand', controller: 'current', or: [{ not: { faction: 'stark' }, printedCostOrLower: 5 }, { trait: 'House Bolton' }] }
+                cardCondition: { location: 'hand', controller: 'current', printedCostOrLower: 5, or: [{ not: { faction: 'stark' } }, { trait: 'House Bolton' }] }
             },
             cost: ability.costs.sacrificeSelf(),
             handler: context => {

--- a/server/game/cards/24-TSoW/TheCrag.js
+++ b/server/game/cards/24-TSoW/TheCrag.js
@@ -11,6 +11,7 @@ class TheCrag extends DrawCard {
             when: {
                 afterChallenge: event => event.challenge.isMatch({ challengeType: 'military', winner: this.controller, attackingPlayer: this.controller })
             },
+            limit: ability.limit.perPhase(2),
             message: {
                 format: '{player} uses {source} to gain {amount} power for their faction',
                 args: { amount: context => this.getAmount(context) }

--- a/server/game/cards/24-TSoW/TheTrident.js
+++ b/server/game/cards/24-TSoW/TheTrident.js
@@ -7,6 +7,7 @@ class TheTrident extends DrawCard {
             claim: 1
         });
         this.forcedReaction({
+            cannotBeCanceled: true,
             when: {
                 afterChallenge: event => event.challenge.winner === this.controller && event.challenge.attackingPlayer === this.controller
             },

--- a/server/game/costs/KneelCost.js
+++ b/server/game/costs/KneelCost.js
@@ -12,7 +12,7 @@ class KneelCost {
     pay(cards, context) {
         context.game.resolveGameAction(
             GameActions.simultaneously(
-                cards.map(card => GameActions.kneelCard({ card }))
+                cards.map(card => GameActions.kneelCard({ card, reason: 'cost' }))
             )
         );
     }

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -744,6 +744,7 @@ const Effects = {
     },
     cannotBringOutOfShadows: function(condition) {
         let restriction = (card, playingType) => playingType === 'outOfShadows' && condition(card);
+        return this.cannotPutIntoPlay(restriction);
     },
     cannotPlay: function(condition) {
         let restriction = (card, playingType) => card.getType() === 'event' && playingType === 'play' && condition(card);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -742,6 +742,9 @@ const Effects = {
         let restriction = (card, playingType) => playingType === 'marshal' && condition(card);
         return this.cannotPutIntoPlay(restriction);
     },
+    cannotBringOutOfShadows: function(condition) {
+        let restriction = (card, playingType) => playingType === 'outOfShadows' && condition(card);
+    },
     cannotPlay: function(condition) {
         let restriction = (card, playingType) => card.getType() === 'event' && playingType === 'play' && condition(card);
         return this.cannotPutIntoPlay(restriction);

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -922,11 +922,11 @@ class Player extends Spectator {
         return !this.putIntoShadowsRestrictions.some(restriction => restriction(card, playingType));
     }
 
-    putIntoShadows(card, reason = 'ability', allowSave = true, callback = () => true) {
+    putIntoShadows(card, allowSave = true, callback = () => true) {
         let playingType = this.game.currentPhase === 'setup' ? 'setup' : 'put';
         if(this.canPutIntoShadows(card, playingType)) {
             this.game.applyGameAction('putIntoShadows', card, card => {
-                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, reason, allowSave: allowSave }, event => {
+                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, allowSave: allowSave }, event => {
                     event.cardStateWhenMoved = card.createSnapshot();
                     this.moveCard(card, 'shadows', { allowSave: allowSave }, callback);
                 });

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -922,11 +922,11 @@ class Player extends Spectator {
         return !this.putIntoShadowsRestrictions.some(restriction => restriction(card, playingType));
     }
 
-    putIntoShadows(card, allowSave = true, callback = () => true) {
+    putIntoShadows(card, reason = 'ability', allowSave = true, callback = () => true) {
         let playingType = this.game.currentPhase === 'setup' ? 'setup' : 'put';
         if(this.canPutIntoShadows(card, playingType)) {
             this.game.applyGameAction('putIntoShadows', card, card => {
-                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, allowSave: allowSave }, event => {
+                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, reason, allowSave: allowSave }, event => {
                     event.cardStateWhenMoved = card.createSnapshot();
                     this.moveCard(card, 'shadows', { allowSave: allowSave }, callback);
                 });


### PR DESCRIPTION
:dart: **Playtesting Website Update - v 24.11**
---

[Download Print & Play PDF (All Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_11_all.pdf)
[Download Print & Play PDF (Changed Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_11_changed.pdf)

### :arrows_clockwise: **Reworked:**
[➥ **Ser Gilbert Farring v1.2**:](https://hcti.io/v1/image/d92c550a-28b1-436e-8845-7a4ba90e7e97)<br>After a quality of life considerations, he has been slightly reworked to fit the level of other 4/4 characters; his passive is conditional on standing loyal locations, and his ability prevents your locations being knelt by abilities (such as assault).
[➥ **Dragonstone v1.2**:](https://hcti.io/v1/image/e89d0002-6eb6-4f5d-af6e-164ac46531f3)<br>Reworked this card to fit the intended direction better; can now keep a card in shadows after put in there via a card effect.
[➥ **One, Two, Three v1.3**:](https://hcti.io/v1/image/c78e2df6-9fa8-4235-bcfc-6203fb9cd3b6)<br>Widening the decks this card can be used in, but lowering it's general strength; you can now choose one character you control for one of the three choices we've been pushing.

### :arrow_double_up: **Updated:**
[➥ **The Myrish Eye v1.1**:](https://hcti.io/v1/image/5fcef9fd-03d1-4857-a5cd-42121b88a101)<br>Making this card unique, and altering it's name to fit the unique item it is refering to.
[➥ **Ser Daven Lannister v1.3**:](https://hcti.io/v1/image/99042e24-cbbb-424e-ab11-8b74c31b5741)<br>In an effort to make this less NPE, opponents now choose their discarded cards rather than discard being random.
[➥ **Ser Andrey Dalt v1.4**:](https://hcti.io/v1/image/75dc0871-27bc-4ed3-8385-3d0cf00b1149)<br>After quality of life considerations, strength has been lowered from ~~4~~ to 3.
[➥ **The Bastard's Boys v1.1**:](https://hcti.io/v1/image/64a743cb-71d7-439d-8a88-99c8ad77c6d7)<br>Altering this card so that it's only bringing in 5 cost or lower characters. Statistically this card has been performing fairly well, however it is/was causing an issue of over-efficiency within a deck that it's intentionally very good in (Lannister Harrenhal decks). This adjustment is ensuring the card has a clear ceiling, and keeps future design in mind by allowing us to comfortably support new expensive ***House Bolton*** characters without it breaking the game.
[➥ **The Crag v1.4**:](https://hcti.io/v1/image/c1b5d9a9-90f5-42af-b791-7d90fef0ad57)<br>Changed to loyal out of concerns of fairly simple efficiency in certain factions (such as core Khal Drogo in Targaryen), and limited to twice per phase.
[➥ **Hero v1.4**:](https://hcti.io/v1/image/335ec83e-4c9d-42c8-94ef-5ba862d59494)<br>Added "No attachments except ***Weapon***" for a slight consistency boost. After this update, we believe this card is on a similar power-level to the other 4/4's in this pack.
[➥ **Highgarden Sept v1.3**:](https://hcti.io/v1/image/90ee86a4-fc0b-4c3f-b90d-97036821cae5)<br>A final quality of life change; passive now only blocks characters from entering play.
[➥ **The Trident v1.4**:](https://hcti.io/v1/image/a7590bea-a44e-4db0-a59b-76c28638ff7f)<br>As a safeguard for potential future abuse, we've re-added "(Cannot be cancelled)" to this ability. Sorry Maester Murenmure!
[➥ **Battle of the Camps v1.4**:](https://hcti.io/v1/image/840ec719-b164-46fe-9541-00a594ed171a)<br>Limiting this ability to once per phase, as there are concerns of extreme over-efficiency in certain challenge repeating factions.

### :wrench: **Bugfixed:**
[➥ **Salladhor Saan's Lyseni**:](https://hcti.io/v1/image/c42e468d-b6c6-48be-adc7-84e07d9d95f2)<br>No longer crashes game, and properly triggers as a reaction, not an interrupt.
[➥ **The Field of Fire**:](https://hcti.io/v1/image/e48d59eb-a916-411b-8d7b-9947eb1446bc)<br>No longer crashes game, and ensures the ***Dragon*** you select must be in play.

---
Closes #381, Closes #382, Closes #383, Closes #384, Closes #385, Closes #386, Closes #387, Closes #388, Closes #389, Closes #390, Closes #391, Closes #392

_Last Updated on Wed Apr 19 2023 02:03:14 GMT+0000 (Coordinated Universal Time)_