### PR TITLE
Make more actions have proper simultaneous leave play event

### DIFF
--- a/server/game/GameActions/ReturnCardToHand.js
+++ b/server/game/GameActions/ReturnCardToHand.js
@@ -1,5 +1,6 @@
 const Message = require('../Message');
 const GameAction = require('./GameAction');
+const LeavePlay = require('./LeavePlay');
 const MoveCardEventGenerator = require('./MoveCardEventGenerator');
 
 class ReturnCardToHand extends GameAction {
@@ -22,6 +23,10 @@ class ReturnCardToHand extends GameAction {
     }
 
     canChangeGameState({ card }) {
+        if(card.location === 'play area' && !LeavePlay.allow({ card })) {
+            return false;
+        }
+
         return ['dead pile', 'discard pile', 'play area', 'shadows', 'duplicate', 'being played'].includes(card.location);
     }
 

--- a/server/game/player.js
+++ b/server/game/player.js
@@ -923,15 +923,7 @@ class Player extends Spectator {
     }
 
     putIntoShadows(card, allowSave = true, callback = () => true) {
-        let playingType = this.game.currentPhase === 'setup' ? 'setup' : 'put';
-        if(this.canPutIntoShadows(card, playingType)) {
-            this.game.applyGameAction('putIntoShadows', card, card => {
-                this.game.raiseEvent('onCardPutIntoShadows', { player: this, card: card, allowSave: allowSave }, event => {
-                    event.cardStateWhenMoved = card.createSnapshot();
-                    this.moveCard(card, 'shadows', { allowSave: allowSave }, callback);
-                });
-            });
-        }
+        return this.game.resolveGameAction(GameActions.putIntoShadows({ card, allowSave })).thenExecute(callback);
     }
 
     shuffleCardIntoDeck(card, allowSave = true) {


### PR DESCRIPTION
* Updates "return card to hand" and "remove from game" to have a simultaneous OnCardLeftPlay event instead of moving
* Updates all `putIntoShadows` calls to use the GameAction, ensuring they have simultaneous OnCardLeftPlay event instead of moving

Fixes #396 