### PR TITLE
Fixing card visibility during "onTargetsChosen" interrupt window

### DIFF
--- a/server/game/AbilityChoiceSelection.js
+++ b/server/game/AbilityChoiceSelection.js
@@ -5,6 +5,7 @@ class AbilityChoiceSelection {
     constructor(options) {
         this.choosingPlayer = options.choosingPlayer;
         this.eligibleChoices = options.eligibleChoices;
+        this.requiresValidation = options.requiresValidation;
         this.targetingType = options.targetingType;
         this.name = options.name;
         this.subResults = options.subResults;

--- a/server/game/AbilityTarget.js
+++ b/server/game/AbilityTarget.js
@@ -43,10 +43,12 @@ class AbilityTarget {
         // Creating the selector once the target is being selected for effects such as keywords with a changing target amount
         this.selector = CardSelector.for({ context, ...this.properties });
         let eligibleCards = this.selector.getEligibleTargets(context);
+        let requiresValidation = this.selector.requiresTargetValidation(context);
         let subResults = this.subTargets.map(subTarget => subTarget.buildPlayerSelection(context));
         return new AbilityChoiceSelection({
             choosingPlayer: context.choosingPlayer,
             eligibleChoices: eligibleCards,
+            requiresValidation: requiresValidation,
             targetingType: this.type,
             subResults: subResults,
 

--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -92,7 +92,7 @@ class CardMatcher {
             dummyMatcher(proxy, context);
 
             return requiresValidation;
-        }
+        };
     }
 }
 

--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -71,6 +71,29 @@ class CardMatcher {
 
         return false;
     }
+
+    static createValidator(propertiesOrFunc) {
+        let dummyMatcher = CardMatcher.createMatcher(propertiesOrFunc);
+        let tracking = ['name', 'factions', 'icons', 'keywords', 'traits', 'cardData'];
+
+        return function(card, context) {
+            let requiresValidation = false;
+            let proxy = new Proxy(card, {
+                // When a tracked property is accessed, then card should require validation
+                get(object, property) {
+                    if(tracking.includes(property)) {
+                        requiresValidation = true;
+                    }
+                    return object[property];
+                }
+            });
+            
+            // Run the proxy test through the matcher
+            dummyMatcher(proxy, context);
+
+            return requiresValidation;
+        }
+    }
 }
 
 module.exports = CardMatcher;

--- a/server/game/CardMatcher.js
+++ b/server/game/CardMatcher.js
@@ -73,22 +73,24 @@ class CardMatcher {
     }
 
     /**
-     * Creates a checker function to determine whether card characteristics are 
-     * involved in a given matcher properties/func. Characteristics would be 
-     * information about the card itself (eg. name, type, strength, icons, etc.) rather 
-     * than information about the cards game-state (eg. location, kneeling, controller, etc.)
+     * Creates an analyzing function which determines whether card attributes are 
+     * involved in a given matcher (via properties/func). "Card attributes" would be 
+     * data about the faceup card itself (eg. name, type, strength, icons, etc.) rather 
+     * than data about the card's game-state (eg. location, kneeling, controller, etc.).
      */
-    static createCardCharacteristicChecker(propertiesOrFunc) {
+    static createCardAttributeAnalyzer(propertiesOrFunc) {
         let dummyMatcher = CardMatcher.createMatcher(propertiesOrFunc);
-        let characteristics = ['name', 'factions', 'icons', 'keywords', 'traits', 'cardData'];
+        // Anything which accesses cardData is checking printed card attributes, whilst other attributes which
+        // have separated from cardData (such as 'name' or any ReferenceCountedProperties) are individually checked
+        let attributeProperties = ['cardData', 'name', 'factions', 'icons', 'keywords', 'traits'];
 
         return function(card, context) {
-            let involvesCharacteristic = false;
+            let involvesAttribute = false;
             let proxy = new Proxy(card, {
-                // Wraps the getter of each property to check if a characteristic is accessed
+                // Wraps the getter of each property to check if an attribute-based property is accessed
                 get(object, property) {
-                    if(characteristics.includes(property)) {
-                        involvesCharacteristic = true;
+                    if(attributeProperties.includes(property)) {
+                        involvesAttribute = true;
                     }
                     return object[property];
                 }
@@ -97,7 +99,7 @@ class CardMatcher {
             // Run the proxy test through the matcher
             dummyMatcher(proxy, context);
 
-            return involvesCharacteristic;
+            return involvesAttribute;
         };
     }
 }

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -23,6 +23,7 @@ class BaseCardSelector {
      */
     constructor(properties) {
         this.cardCondition = CardMatcher.createMatcher(properties.cardCondition);
+        this.cardValidation = CardMatcher.createValidator(properties.cardCondition);
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
@@ -65,6 +66,15 @@ class BaseCardSelector {
      */
     getEligibleTargets(context) {
         return context.game.allCards.filter(card => this.canTarget(card, context));
+    }
+
+    /**
+     * Returns whether this selector requires proof that the chosen card is a valid target.
+     *  @param {AbilityContext} context
+     *  @returns {boolean}
+     */
+    requiresTargetValidation(context) {
+        return this.getEligibleTargets(context).some(card => this.cardValidation(card, context))
     }
 
     /**

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -23,7 +23,7 @@ class BaseCardSelector {
      */
     constructor(properties) {
         this.cardCondition = CardMatcher.createMatcher(properties.cardCondition);
-        this.checksCardCharacteristic = CardMatcher.createCardCharacteristicChecker(properties.cardCondition);
+        this.isCardAttributeAccessed = CardMatcher.createCardAttributeAnalyzer(properties.cardCondition);
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
@@ -74,7 +74,7 @@ class BaseCardSelector {
      *  @returns {boolean}
      */
     requiresTargetValidation(context) {
-        return this.getEligibleTargets(context).some(card => this.checksCardCharacteristic(card, context));
+        return this.getEligibleTargets(context).some(card => this.isCardAttributeAccessed(card, context));
     }
 
     /**

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -23,7 +23,7 @@ class BaseCardSelector {
      */
     constructor(properties) {
         this.cardCondition = CardMatcher.createMatcher(properties.cardCondition);
-        this.cardValidation = CardMatcher.createValidator(properties.cardCondition);
+        this.checksCardCharacteristic = CardMatcher.createCardCharacteristicChecker(properties.cardCondition);
         this.cardType = properties.cardType;
         this.gameAction = properties.gameAction;
         this.singleController = properties.singleController;
@@ -74,7 +74,7 @@ class BaseCardSelector {
      *  @returns {boolean}
      */
     requiresTargetValidation(context) {
-        return this.getEligibleTargets(context).some(card => this.cardValidation(card, context));
+        return this.getEligibleTargets(context).some(card => this.checksCardCharacteristic(card, context));
     }
 
     /**

--- a/server/game/CardSelectors/BaseCardSelector.js
+++ b/server/game/CardSelectors/BaseCardSelector.js
@@ -74,7 +74,7 @@ class BaseCardSelector {
      *  @returns {boolean}
      */
     requiresTargetValidation(context) {
-        return this.getEligibleTargets(context).some(card => this.cardValidation(card, context))
+        return this.getEligibleTargets(context).some(card => this.cardValidation(card, context));
     }
 
     /**

--- a/server/game/ChallengeMatcher.js
+++ b/server/game/ChallengeMatcher.js
@@ -3,19 +3,19 @@ const Matcher = require('./Matcher');
 class ChallengeMatcher {
     static isMatch(challenge, matchers) {
         return (
-            Matcher.containsValue(matchers.initiatingPlayer, challenge.initiatingPlayer) &&
-            Matcher.containsValue(matchers.initiatedChallengeType, challenge.initiatedChallengeType) &&
-            Matcher.containsValue(matchers.challengeType, challenge.challengeType) &&
-            Matcher.containsValue(matchers.attackingPlayer, challenge.attackingPlayer) &&
-            Matcher.containsValue(matchers.defendingPlayer, challenge.defendingPlayer) &&
-            Matcher.containsValue(matchers.initiated, challenge.isInitiated) &&
-            Matcher.containsValue(matchers.initiatedAgainstPlayer, challenge.initiatedAgainstPlayer) &&
-            Matcher.containsValue(matchers.loser, challenge.loser) &&
-            Matcher.containsValue(matchers.winner, challenge.winner) &&
+            Matcher.containsValue(matchers.initiatingPlayer, () => challenge.initiatingPlayer) &&
+            Matcher.containsValue(matchers.initiatedChallengeType, () => challenge.initiatedChallengeType) &&
+            Matcher.containsValue(matchers.challengeType, () => challenge.challengeType) &&
+            Matcher.containsValue(matchers.attackingPlayer, () => challenge.attackingPlayer) &&
+            Matcher.containsValue(matchers.defendingPlayer, () => challenge.defendingPlayer) &&
+            Matcher.containsValue(matchers.initiated, () => challenge.isInitiated) &&
+            Matcher.containsValue(matchers.initiatedAgainstPlayer, () => challenge.initiatedAgainstPlayer) &&
+            Matcher.containsValue(matchers.loser, () => challenge.loser) &&
+            Matcher.containsValue(matchers.winner, () => challenge.winner) &&
             Matcher.anyValue(matchers.attackingAlone, card => card.isAttacking() && challenge.attackers.length === 1) &&
             Matcher.anyValue(matchers.defendingAlone, card => card.isDefending() && challenge.defenders.length === 1) &&
-            Matcher.containsValue(matchers.number, challenge.number) &&
-            Matcher.containsValue(matchers.unopposed, challenge.isUnopposed()) &&
+            Matcher.containsValue(matchers.number, () => challenge.number) &&
+            Matcher.containsValue(matchers.unopposed, () => challenge.isUnopposed()) &&
             Matcher.anyValue(matchers.by5, value => (challenge.strengthDifference >= 5) === value) &&
             Matcher.anyValue(matchers.match, func => func(challenge)) &&
             Matcher.anyValue(matchers.not, notProperties => !ChallengeMatcher.isMatch(challenge, notProperties)) &&

--- a/server/game/Matcher.js
+++ b/server/game/Matcher.js
@@ -4,16 +4,16 @@ class Matcher {
      * the expected value is an array, it returns true if the actual value is
      * contained in that array.
      */
-    static containsValue(expected, actual) {
+    static containsValue(expected, actualFunc) {
         if(expected === undefined) {
             return true;
         }
 
         if(Array.isArray(expected)) {
-            return expected.includes(actual);
+            return expected.includes(actualFunc());
         }
 
-        return expected === actual;
+        return expected === actualFunc();
     }
 
     /**

--- a/server/game/basecard.js
+++ b/server/game/basecard.js
@@ -767,7 +767,13 @@ class BaseCard {
         return 'card';
     }
 
-    getShortSummary() {
+    getShortSummary(isVisible = true) {
+        if(!isVisible) {
+            return {
+                facedown: true,
+                shadowPosition: this.location === 'shadows' ? this.controller.shadows.indexOf(this) + 1 : undefined
+            };
+        }
         return {
             code: this.cardData.code,
             label: this.cardData.label,

--- a/server/game/gamesteps/ResolvedTargets.js
+++ b/server/game/gamesteps/ResolvedTargets.js
@@ -39,23 +39,12 @@ class ResolvedTargets {
         return flatten(targetingSelections.map(selection => selection.value));
     }
 
-    getViewableFor(game, player) {
+    getShortSummariesForPlayer(game, player) {
         let targetingSelections = this.selections.filter(selection => selection.resolved && selection.hasValue() && selection.targetingType === 'choose');
-        return targetingSelections.reduce((result, selection) => {
+        return targetingSelections.reduce((summaries, selection) => {
             let cards = Array.isArray(selection.value) ? flatten(selection.value) : [selection.value];
-            if(selection.requiresValidation) {
-                result.viewable = result.viewable.concat(cards);
-            } else {
-                for(let card of cards) {
-                    if(game.isCardVisible(card, player)) {
-                        result.viewable.push(card);
-                    } else {
-                        result.hidden.push(card);
-                    }
-                }
-            }
-            return result;
-        }, { viewable: [], hidden: [] });
+            return summaries.concat(cards.map(card => selection.requiresValidation || game.isCardVisible(card, player) ? card.getShortSummary() : { facedown: true }));
+        }, []);
     }
 
     getTargetsForPlayer(player) {

--- a/server/game/gamesteps/ResolvedTargets.js
+++ b/server/game/gamesteps/ResolvedTargets.js
@@ -39,12 +39,9 @@ class ResolvedTargets {
         return flatten(targetingSelections.map(selection => selection.value));
     }
 
-    getShortSummariesForPlayer(game, player) {
-        let targetingSelections = this.selections.filter(selection => selection.resolved && selection.hasValue() && selection.targetingType === 'choose');
-        return targetingSelections.reduce((summaries, selection) => {
-            let cards = Array.isArray(selection.value) ? flatten(selection.value) : [selection.value];
-            return summaries.concat(cards.map(card => selection.requiresValidation || game.isCardVisible(card, player) ? card.getShortSummary() : { facedown: true }));
-        }, []);
+    getTargetsToValidate() {
+        let targetingSelections = this.selections.filter(selection => selection.hasValue() && selection.requiresValidation);
+        return flatten(targetingSelections.map(selection => selection.value));
     }
 
     getTargetsForPlayer(player) {

--- a/server/game/gamesteps/ResolvedTargets.js
+++ b/server/game/gamesteps/ResolvedTargets.js
@@ -39,6 +39,25 @@ class ResolvedTargets {
         return flatten(targetingSelections.map(selection => selection.value));
     }
 
+    getViewableFor(game, player) {
+        let targetingSelections = this.selections.filter(selection => selection.resolved && selection.hasValue() && selection.targetingType === 'choose');
+        return targetingSelections.reduce((result, selection) => {
+            let cards = Array.isArray(selection.value) ? flatten(selection.value) : [selection.value];
+            if(selection.requiresValidation) {
+                result.viewable = result.viewable.concat(cards);
+            } else {
+                for(let card of cards) {
+                    if(game.isCardVisible(card, player)) {
+                        result.viewable.push(card);
+                    } else {
+                        result.hidden.push(card);
+                    }
+                }
+            }
+            return result;
+        }, { viewable: [], hidden: [] });
+    }
+
     getTargetsForPlayer(player) {
         let selectionsForPlayer = this.selections.filter(selection => selection.choosingPlayer === player);
         let result = new ResolvedTargets();

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -52,7 +52,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
             cardCondition: card => cardsForPlayer.includes(card),
             cardType: ['agenda', 'attachment', 'character', 'event', 'location', 'plot', 'title'],
             additionalButtons: this.getButtons(player, unclickableCards),
-            additionalControls: this.getAdditionalPromptControls(),
+            additionalControls: this.getAdditionalPromptControls(player),
             doneButtonText: 'Pass',
             onSelect: (player, card) => this.chooseCardToTrigger(player, card),
             onCancel: () => this.pass(),
@@ -88,7 +88,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         return buttons;
     }
 
-    getAdditionalPromptControls() {
+    getAdditionalPromptControls(player) {
         let controls = [];
         for(let event of this.event.getConcurrentEvents()) {
             if(event.name === 'onCardAbilityInitiated' && event.targets.length > 0) {
@@ -98,10 +98,11 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                     targets: event.targets.map(target => target.getShortSummary())
                 });
             } else if(event.name === 'onTargetsChosen') {
+                let viewableTargets = event.targets.getViewableFor(this.game, player);
                 controls.push({
                     type: 'targeting',
                     source: event.ability.card.getShortSummary(),
-                    targets: event.targets.getTargets().map(target => target.getShortSummary())
+                    targets: viewableTargets.viewable.map(target => target.getShortSummary()).concat(viewableTargets.hidden.map(() => ({ facedown: true })))
                 });
             }
         }

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -109,8 +109,8 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
         return controls;
     }
 
-    buildTargetSummaries(player, targets, forced) {
-        return targets.map(target => forced.includes(target) || this.game.isCardVisible(target, player) ? target.getShortSummary() : { facedown: true });
+    buildTargetSummaries(player, targets, targetsToValidate) {
+        return targets.map(target => targetsToValidate.includes(target) || this.game.isCardVisible(target, player) ? target.getShortSummary() : { facedown: true });
     }
 
     chooseCardToTrigger(player, card) {

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -95,18 +95,22 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                 controls.push({
                     type: 'targeting',
                     source: event.source.getShortSummary(),
-                    targets: event.targets.map(target => target.getShortSummary())
+                    targets: this.buildTargetSummaries(player, event.targets, event.targetsToValidate)
                 });
             } else if(event.name === 'onTargetsChosen') {
                 controls.push({
                     type: 'targeting',
                     source: event.ability.card.getShortSummary(),
-                    targets: event.targets.getShortSummariesForPlayer(this.game, player)
+                    targets: this.buildTargetSummaries(player, event.targets.getTargets(), event.targets.getTargetsToValidate())
                 });
             }
         }
 
         return controls;
+    }
+
+    buildTargetSummaries(player, targets, forced) {
+        return targets.map(target => forced.includes(target) || this.game.isCardVisible(target, player) ? target.getShortSummary() : { facedown: true });
     }
 
     chooseCardToTrigger(player, card) {

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -98,11 +98,10 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
                     targets: event.targets.map(target => target.getShortSummary())
                 });
             } else if(event.name === 'onTargetsChosen') {
-                let viewableTargets = event.targets.getViewableFor(this.game, player);
                 controls.push({
                     type: 'targeting',
                     source: event.ability.card.getShortSummary(),
-                    targets: viewableTargets.viewable.map(target => target.getShortSummary()).concat(viewableTargets.hidden.map(() => ({ facedown: true })))
+                    targets: event.targets.getShortSummariesForPlayer(this.game, player)
                 });
             }
         }

--- a/server/game/gamesteps/TriggeredAbilityWindow.js
+++ b/server/game/gamesteps/TriggeredAbilityWindow.js
@@ -110,7 +110,7 @@ class TriggeredAbilityWindow extends BaseAbilityWindow {
     }
 
     buildTargetSummaries(player, targets, targetsToValidate) {
-        return targets.map(target => targetsToValidate.includes(target) || this.game.isCardVisible(target, player) ? target.getShortSummary() : { facedown: true });
+        return targets.map(target => target.getShortSummary(targetsToValidate.includes(target) || this.game.isCardVisible(target, player)));
     }
 
     chooseCardToTrigger(player, card) {

--- a/server/game/gamesteps/abilityresolver.js
+++ b/server/game/gamesteps/abilityresolver.js
@@ -194,7 +194,9 @@ class AbilityResolver extends BaseStep {
         // thus is not subject to cancels such as Treachery.
         if(this.ability.isCardAbility()) {
             let targets = this.context.targets.getTargets();
-            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source, ability: this.ability, targets: targets, originalLocation: this.context.originalLocation }, () => {
+            // Collect cards which require validation/proof that it is actually a valid target for ability
+            let targetsToValidate = this.context.targets.getTargetsToValidate();
+            this.game.raiseEvent('onCardAbilityInitiated', { player: this.context.player, source: this.context.source, ability: this.ability, targets: targets, targetsToValidate: targetsToValidate, originalLocation: this.context.originalLocation }, () => {
                 this.ability.executeHandler(this.context);
             });
         } else {

--- a/test/server/CardMatcher.spec.js
+++ b/test/server/CardMatcher.spec.js
@@ -141,7 +141,9 @@ describe('CardMatcher', function() {
                 this.cardSpy.location = 'hand';
                 // Need to 'strictly' define function to ensure it's scope is within the proxy 
                 // created in the checker (eg. "this" will refer to the proxy, rather than this test's context)
-                this.cardSpy.getType.and.callFake(function() { return this.cardData.type });
+                this.cardSpy.getType.and.callFake(function() {
+                    return this.cardData.type;
+                });
             });
 
             it('should return true when primitive property characteristics are checked (eg. name)', function() {
@@ -171,7 +173,3 @@ describe('CardMatcher', function() {
         });
     });
 });
-
-function isLoyal() {
-    return this.cardData.loyal;
-}

--- a/test/server/Matcher.spec.js
+++ b/test/server/Matcher.spec.js
@@ -3,20 +3,20 @@ const Matcher = require('../../server/game/Matcher.js');
 describe('Matcher', function() {
     describe('containsValue', function() {
         it('should return true when the expected value is undefined', function() {
-            expect(Matcher.containsValue(undefined, 1)).toBe(true);
+            expect(Matcher.containsValue(undefined, () => 1)).toBe(true);
         });
 
         it('should return true when the values match', function() {
-            expect(Matcher.containsValue(1, 1)).toBe(true);
+            expect(Matcher.containsValue(1, () => 1)).toBe(true);
         });
 
         it('should return false when the values do not match', function() {
-            expect(Matcher.containsValue(2, 1)).toBe(false);
+            expect(Matcher.containsValue(2, () => 1)).toBe(false);
         });
 
         describe('when the expected value is an array', function() {
             it('should return true if the actual value is contained in the array', function() {
-                expect(Matcher.containsValue([1, 2, 3], 2)).toBe(true);
+                expect(Matcher.containsValue([1, 2, 3], () => 2)).toBe(true);
             });
         });
     });

--- a/test/server/gamesteps/abilityresolver.spec.js
+++ b/test/server/gamesteps/abilityresolver.spec.js
@@ -18,9 +18,10 @@ describe('AbilityResolver', function() {
         this.player = jasmine.createSpyObj('player', ['moveCard']);
         this.source = jasmine.createSpyObj('source', ['createSnapshot', 'getType']);
         this.source.owner = this.player;
-        let targets = jasmine.createSpyObj('targets', ['getTargets', 'hasTargets', 'setSelections', 'updateTargets']);
+        let targets = jasmine.createSpyObj('targets', ['getTargets', 'hasTargets', 'setSelections', 'updateTargets', 'getTargetsToValidate']);
         targets.hasTargets.and.returnValue(true);
         targets.getTargets.and.returnValue([]);
+        targets.getTargetsToValidate.and.returnValue([]);
         this.context = { foo: 'bar', player: this.player, source: this.source, targets: targets };
         this.resolver = new AbilityResolver(this.game, this.ability, this.context);
     });
@@ -65,7 +66,7 @@ describe('AbilityResolver', function() {
             });
 
             it('should raise the onCardAbilityInitiated event', function() {
-                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, ability: this.ability, targets: [], originalLocation: undefined }, jasmine.any(Function));
+                expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, ability: this.ability, targets: [], targetsToValidate: [], originalLocation: undefined }, jasmine.any(Function));
             });
         });
 
@@ -210,6 +211,7 @@ describe('AbilityResolver', function() {
                         beforeEach(function() {
                             this.targetResult.name = 'foo';
                             this.context.targets.getTargets.and.returnValue([this.target]);
+                            this.context.targets.getTargetsToValidate.and.returnValue([this.target]);
                             this.resolver.continue();
                         });
 
@@ -226,7 +228,7 @@ describe('AbilityResolver', function() {
                         });
 
                         it('should raise the onCardAbilityInitiated event with appropriate targets', function() {
-                            expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, ability: this.ability, targets: [this.target], originalLocation: this.context.originalLocation }, jasmine.any(Function));
+                            expect(this.game.raiseEvent).toHaveBeenCalledWith('onCardAbilityInitiated', { player: this.player, source: this.source, ability: this.ability, targets: [this.target], targetsToValidate: [this.target], originalLocation: this.context.originalLocation }, jasmine.any(Function));
                         });
                     });
 


### PR DESCRIPTION
Should successfully show cards that are either visible to the prompted player, or **must** be shown in order to validate that chosen card as a valid target for the effect, and should hide every other card.

TODO:
- [x]  Add tests, likely using something like Obara Sand (SoD) for showing, and Traitors Whisper for hiding.

Closes: #203 