### PR TITLE
Playtesting Update - v 24.12

### DIFF
--- a/server/game/cards/24-TSoW/BrokenMen.js
+++ b/server/game/cards/24-TSoW/BrokenMen.js
@@ -11,9 +11,9 @@ class BrokenMen extends DrawCard {
             target: {
                 cardCondition: { participating: true, or: [{ printedCostOrLower: 4 }, { trait: 'Army' }]}
             },
-            message: '{player} plays {source} and sacrifices {costs.sacrificeCard} to remove {target} from the game',
+            message: '{player} plays {source} and sacrifices {costs.sacrificeCard} to discard {target} from play',
             handler: context => {
-                this.game.resolveGameAction(GameActions.removeFromGame(context => ({ card: context.target })), context);
+                this.game.resolveGameAction(GameActions.discardCard(context => ({ card: context.target, source: this })), context);
             }
         });
     }

--- a/server/game/cards/24-TSoW/SerGilbertFarring.js
+++ b/server/game/cards/24-TSoW/SerGilbertFarring.js
@@ -1,23 +1,14 @@
 const DrawCard = require('../../drawcard.js');
-const GameActions = require('../../GameActions/index.js');
 
 class SerGilbertFarring extends DrawCard {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            condition: () => this.controller.anyCardsInPlay({ loyal: true, type: 'location', kneeled: false }),
+            condition: () => this.controller.anyCardsInPlay({ trait: 'Stronghold', type: 'location' }),
             match: this,
-            effect: ability.effects.addKeyword('Renown')
-        });
-        this.reaction({
-            when: {
-                onCardKneeled: event => event.card.isFaction('baratheon')
-                                        && event.card.getType() === 'location' 
-                                        && event.card.controller === this.controller
-                                        && ['assault', 'ability'].includes(event.reason)
-            },
-            cost: ability.costs.standSelf(),
-            limit: ability.limit.perPhase(1),
-            gameAction: GameActions.standCard(context => ({ card: context.event.card }))
+            effect: [
+                ability.effects.addKeyword('Renown'),
+                ability.effects.doesNotKneelAsDefender()
+            ]
         });
     }
 }

--- a/server/game/cards/24-TSoW/TheFieldOfFire.js
+++ b/server/game/cards/24-TSoW/TheFieldOfFire.js
@@ -16,7 +16,7 @@ class TheFieldOfFire extends DrawCard {
                     match: card => card.getType() === 'character' && !card.hasTrait('Dragon') && card.attachments.length === 0 && card.location === 'play area',
                     targetController: 'any',
                     effect: ability.effects.modifyStrength(this.getReductionAmount(context.player))
-                }))
+                }));
             })
         });
     }

--- a/server/game/cards/24-TSoW/TheFieldOfFire.js
+++ b/server/game/cards/24-TSoW/TheFieldOfFire.js
@@ -3,39 +3,26 @@ const GameActions = require('../../GameActions/index.js');
 
 class TheFieldOfFire extends DrawCard {
     setupCardAbilities(ability) {
-        this.reaction({
-            when: {
-                onPhaseStarted: event => event.phase === 'challenge'
-            },
-            cost: ability.costs.kneelFactionCard(),
-            target: {
-                cardCondition: { trait: 'Dragon', type: 'character', controller: 'current', location: 'play area' }
-            },
+        this.action({
+            title: 'Give non-Dragon\'s -STR',
+            phase: 'challenge',
             message: {
-                format: '{player} plays {source} to choose {target} and give each character with printed STR {lowerSTR} or lower -1 STR until the end of the phase.',
-                args: { lowerSTR: context => context.target.getPrintedStrength() - 1 }
+                format: '{player} plays {source} to have each non-Dragon character without attachments get {reduction} STR until the end of the phase',
+                args: { reduction: context => this.getReductionAmount(context.player) }
             },
-            handler: context => {
-                this.game.resolveGameAction(
-                    GameActions.simultaneously([
-                        GameActions.genericHandler(context => {
-                            this.untilEndOfPhase(ability => ({
-                                match: card => card.getType() === 'character' && card.getPrintedStrength() < context.target.getPrintedStrength(),
-                                targetController: 'any',
-                                effect: ability.effects.modifyStrength(-1)
-                            }));
-                        }),
-                        GameActions.genericHandler(() => {
-                            this.untilEndOfPhase(ability => ({
-                                match: card => card.getType() === 'character' && card.hasTrait('Army'),
-                                targetController: 'any',
-                                effect: ability.effects.burn
-                            }));
-                        })
-                    ])
-                    , context);
-            }
+            max: ability.limit.perPhase(1),
+            gameAction: GameActions.genericHandler(context => {
+                this.untilEndOfPhase(ability => ({
+                    match: card => card.getType() === 'character' && !card.hasTrait('Dragon') && card.attachments.length === 0 && card.location === 'play area',
+                    targetController: 'any',
+                    effect: ability.effects.modifyStrength(this.getReductionAmount(context.player))
+                }))
+            })
         });
+    }
+
+    getReductionAmount(player) {
+        return player.getNumberOfCardsInPlay({ trait: 'Dragon', type: 'character', controller: 'current', location: 'play area', printedCostOrHigher: 7 }) * -1;
     }
 }
 


### PR DESCRIPTION
:dart: **Playtesting Website Update - v 24.12**
---

[Download Print & Play PDF (All Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_12_all.pdf)
[Download Print & Play PDF (Changed Cards)](https://agot-playtesting.s3.amazonaws.com/printing/TSoW_Playtesting_Sheet_v24_12_changed.pdf)

### :arrows_clockwise: **Reworked:**
[➥ **Ser Gilbert Farring v1.3**:](https://hcti.io/v1/image/7d4a63bd-c835-49f9-a823-4e23e80ef902)<br>Reworked to a more stable, simple ability that reflects Farring's defensive thematics with ***Stronghold***'s; gains renown & doesn't kneel to defend when you control one.
[➥ **Defending the Wall v1.2**:](https://hcti.io/v1/image/3122d110-96d1-438e-84ab-bc57758ab9a0)<br>Slight rework; trialing this as a stand/remove effect with a bonus on ***Army*** and ***Wildling*** cards not being stood. Passive condition added to balance.
[➥ **The Field of Fire v1.3**:](https://hcti.io/v1/image/cb053472-1394-4709-897b-090b39cc462e)<br>After a long discussion involving the intention of this card, we have reworked it to explicitly only work with the 7 cost ***Dragon***s, and removed the ***Army*** synergy. To compensate, the ability now stacks with each ***Dragon***, does not have the faction kneel cost & is more flexible as a **Challenges Action**. This card's intention is to push for a new direction for burn, rather than supporting the pre-existing package which borders the restricted list frequently; "wide but low" is the general idea of this direction, with the large dragons being good examples of that ~ if it also supports underplayed cards, that's a bonus!

### :arrow_double_up: **Updated:**
[➥ **Ser Andrey Dalt v1.5**:](https://hcti.io/v1/image/ef4c863a-60fc-48fd-b62b-8d414412a8f2)<br>Raising STR back to 4, and removing the renown; we did not think this character needs the renown, both thematically or mechanically - therefore we're "trimming the fat", and sticking to a reliable body with a decent passive.
[➥ **The Bastard's Boys v1.2**:](https://hcti.io/v1/image/185170d5-5fef-41c8-8719-4dc22105f97c)<br>This card has been proven to be extremely efficient with Our Blades are Sharp, but don't want to weaken it into unplayable territory; therefore we're removing the "No attachments" keyword to provide a wider avenue of counterplay without harming how this card will usually be played.
[➥ **Broken Men v1.2**:](https://hcti.io/v1/image/3f865cef-3b8f-4472-9d2b-a631acf5df77)<br>Now discards the chosen card, rather than removing it from the game.

### :wrench: **Bugfixed:**
[➥ **Caggo Corpsekiller**:](https://hcti.io/v1/image/ed76d8e1-9f48-4d96-99e5-a579c6e64f77)<br>Fixed various bugs involving Caggo'd characters keeping certain "in play" characteristics, such as continuing to participate towards a challenge whilst in the dead pile. Some bugs may still exist; please report them if you find them!

---
Closes #399, Closes #402, Closes #406, Closes #407, Closes #409, Closes #410

_Last Updated on Wed May 03 2023 12:08:27 GMT+0000 (Coordinated Universal Time)_