### PR TITLE
Updating instance format & added reviewFormId

### DIFF
--- a/config/default.json5
+++ b/config/default.json5
@@ -1,6 +1,9 @@
 {
     env: 'development',
-    instance: 'development',
+    // This is for specific instance-based data which will be passed into each game; not required.
+    //instance: {
+    //    type: 'development'
+    //},
 
     secret: 'somethingverysecret',
     hmacSecret: 'somethingevenmoresecret',

--- a/server/game/game.js
+++ b/server/game/game.js
@@ -115,7 +115,7 @@ class Game extends EventEmitter {
     }
 
     isPlaytesting() {
-        return this.instance === 'playtesting';
+        return this.instance.type === 'playtesting';
     }
 
     reportError(e) {

--- a/server/game/gamesteps/GameWonPrompt.js
+++ b/server/game/gamesteps/GameWonPrompt.js
@@ -18,8 +18,8 @@ class GameWonPrompt extends AllPlayerPrompt {
             { arg: 'rematch', text: 'Rematch' }
         ];
 
-        if(this.game.isPlaytesting()) {
-            buttons.unshift({ arg: 'review', text: 'Open card review page (external page)' });
+        if(this.game.isPlaytesting() && this.game.instance.reviewFormId) {
+            buttons.unshift({ arg: `googleForm:${this.game.instance.reviewFormId}`, text: 'Submit card review (external page)' });
         }
 
         return {

--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ const ServiceFactory = require('./services/ServiceFactory.js');
 let configService = ServiceFactory.configService();
 
 function runServer() {
-    let options = { db: monk(configService.getValue('dbPath')), instance: configService.getValue('instance') };
+    let options = { db: monk(configService.getValue('dbPath')), instance: configService.getValue('instance') || {} };
 
     let server = new Server(process.env.NODE_ENV !== 'production');
     let httpServer = server.init(options);


### PR DESCRIPTION
Minor backend update to ensure that playtesting information can be customized easily through the "instance" object in `local.json5`. Currently it will only use 'type' & 'reviewFormId', but the plan is to allow for further customization to tailor the playtesting experience.