### PR TITLE
Reverting gitmodules changes for live

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "throneteki-json-data"]
 	path = throneteki-json-data
-	url = https://github.com/throneteki-playtesting/throneteki-json-data
+	url = https://github.com/throneteki/throneteki-json-data


### PR DESCRIPTION
Will be reverting this on all development-* branches, and applying the change to playtesting branch only. This means that playtesting will always reference throneteki-playtesting data, without that change accidentally being pushed to live when development-* merges into throneteki/throneteki/master