### PR TITLE
Reworking assault (and other keywords) to updated ruling for KRB

### DIFF
--- a/server/game/ChallengeKeywordAbility.js
+++ b/server/game/ChallengeKeywordAbility.js
@@ -1,21 +1,30 @@
 const BaseAbility = require('./baseability.js');
 
-class KeywordAbility extends BaseAbility {
+class ChallengeKeywordAbility extends BaseAbility {
     constructor(title, properties) {
         super(properties);
         this.title = title;
         this.baseTriggerAmount = 1;
+        this.orderBy = false;
     }
 
     defaultTargetPromptTitle(context) {
-        var keyword = this.title.toLowerCase();
-        var numTargets = this.getTriggerAmount(context);
+        let keyword = this.title.toLowerCase();
+        let numTargets = this.getTriggerAmount(context);
         return `Select ${numTargets === 1 ? `${keyword} target` : `up to ${numTargets} ${keyword} targets`} for ${context.source.name}`;
     }
 
     getTriggerAmount(context) {
         return this.baseTriggerAmount + context.source.getKeywordTriggerModifier(this.title);
     }
+
+    meetsKeywordRequirements() {
+        return true;
+    }
+
+    meetsRequirements(context) {
+        return context.source.allowGameAction(this.title, context) && this.meetsKeywordRequirements(context) && this.getTriggerAmount(context) > 0;
+    }
 }
 
-module.exports = KeywordAbility;
+module.exports = ChallengeKeywordAbility;

--- a/server/game/GameActions/InitiateChallenge.js
+++ b/server/game/GameActions/InitiateChallenge.js
@@ -2,11 +2,6 @@ const GameAction = require('./GameAction');
 const DeclareAttackers = require('./DeclareAttackers');
 const DeclareDefenders = require('./DeclareDefenders');
 
-const GameKeywords = require('../gamekeywords.js');
-const AbilityContext = require('../AbilityContext.js');
-
-const initiatingKeywords = ['stealth', 'assault'];
-
 class InitiateChallenge extends GameAction {
     constructor() {
         super('initiateChallenge');
@@ -39,27 +34,6 @@ class InitiateChallenge extends GameAction {
                     challenge.attackingPlayer, challenge.challengeType, challenge.defendingPlayer, challenge.attackerStrength, challenge.defenderStrength);
             });
         });
-    }
-
-    resolveKeywords({ challenge }) {
-        const declaredAttackersWithContext = challenge.declaredAttackers.map(card => {
-            return { card: card, context: new AbilityContext({ player: challenge.attackingPlayer, game: challenge.game, challenge, source: card }) };
-        });
-        for(let keyword of initiatingKeywords) {
-            let ability = GameKeywords[keyword];
-            let resolveables = declaredAttackersWithContext.filter(attacker => attacker.card.hasKeyword(keyword) && ability.canResolve(attacker.context));
-
-            if(keyword === 'assault') {
-                let highestPrintedCost = Math.max(...resolveables.map(r => r.card.getPrintedCost()));
-                let highestResolvable = resolveables.find(resolveable => resolveable.card.getPrintedCost() === highestPrintedCost);
-                // TODO: Potentially change to select who you want to assault with, for any characters with special interactions with assault
-                if(highestResolvable) {
-                    challenge.game.resolveAbility(ability, highestResolvable.context);
-                }
-            } else {
-                resolveables.forEach(attacker => challenge.game.resolveAbility(ability, attacker.context));
-            }
-        }
     }
 }
 

--- a/server/game/assaultkeyword.js
+++ b/server/game/assaultkeyword.js
@@ -7,6 +7,7 @@ class AssaultKeyword extends KeywordAbility {
             target: {
                 activePromptTitle: context => this.defaultTargetPromptTitle(context),
                 numCards: context => this.getTriggerAmount(context),
+                optional: true,
                 cardCondition: (card, context) => TargetByAssault.allow({ card, source: context.source, challenge: context.challenge })
             },
             message: {
@@ -22,8 +23,24 @@ class AssaultKeyword extends KeywordAbility {
         });
     }
 
+    getTriggerAmount(context) {
+        // Need to offset the base trigger amount based on previously-resolved assault targets, and whether they "used" the baseTriggerAmount in their targeting.
+        // eg. King Robb's Bannermen can assault 2 locations, but attacker chooses to only assault 1; offset would be 0, as the base trigger amount was 
+        //     not actually "used", and thus the next character may assault 1 location. Similarly, if the other character instead assaulted 1 location first ("using" 
+        //     that base trigger amount), then King Robb's Bannermen would only be able to assault 1 location, as the base has been "used", but only it can assault 1 
+        //     additional location, on top of that base.
+        let totalBaseTriggerOffset = context.resolved.reduce((offset, resolvedAssault) => offset += resolvedAssault.context.baseTriggerOffset, 0);
+        return Math.max(super.getTriggerAmount(context) + totalBaseTriggerOffset, 0);
+    }
+
     meetsRequirements(context) {
-        return context.source.isAttacking() && context.source.allowGameAction('targetUsingAssault', context);
+        return context.source.isAttacking() && context.source.allowGameAction('targetUsingAssault', context) && this.getTriggerAmount(context) > 0;
+    }
+
+    executeHandler(context) {
+        let additionalTriggers = this.getTriggerAmount(context) - this.baseTriggerAmount;
+        context.baseTriggerOffset = Math.min(additionalTriggers - context.targets.getTargets().length, 0);
+        super.executeHandler(context);
     }
 }
 

--- a/server/game/assaultkeyword.js
+++ b/server/game/assaultkeyword.js
@@ -1,7 +1,7 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const TargetByAssault = require('./GameActions/TargetByAssault.js');
 
-class AssaultKeyword extends KeywordAbility {
+class AssaultKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Assault', {
             target: {
@@ -21,6 +21,8 @@ class AssaultKeyword extends KeywordAbility {
                 });
             }
         });
+        // Order by highest printed cost (sorts by smallest values first)
+        this.orderBy = context => -context.source.getPrintedCost();
     }
 
     getTriggerAmount(context) {
@@ -33,8 +35,8 @@ class AssaultKeyword extends KeywordAbility {
         return Math.max(super.getTriggerAmount(context) + totalBaseTriggerOffset, 0);
     }
 
-    meetsRequirements(context) {
-        return context.source.isAttacking() && context.source.allowGameAction('targetUsingAssault', context) && this.getTriggerAmount(context) > 0;
+    meetsKeywordRequirements(context) {
+        return context.source.isAttacking();
     }
 
     executeHandler(context) {

--- a/server/game/cards/titles/CrownRegent.js
+++ b/server/game/cards/titles/CrownRegent.js
@@ -1,5 +1,5 @@
 const TitleCard = require('../../TitleCard.js');
-const InitiateChallenge = require('../../GameActions/InitiateChallenge.js');
+const InitiatingKeywordsWindow = require('../../gamesteps/InitiatingKeywordsWindow.js');
 
 class CrownRegent extends TitleCard {
     setupCardAbilities(ability) {
@@ -21,7 +21,7 @@ class CrownRegent extends TitleCard {
                     onSelect: opponent => {
                         challenge.defendingPlayer = opponent;
                         challenge.clearInitiationActions();
-                        InitiateChallenge.resolveKeywords({ challenge });
+                        this.game.queueStep(new InitiatingKeywordsWindow(this.game, challenge));
                     },
                     onCancel: () => {
                         this.game.addAlert('danger', '{0} cancels the challenge redirect', context.event.challenge.attackingPlayer);

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -814,8 +814,8 @@ const Effects = {
         };
     },
     cannotTarget: cannotEffect('target'),
-    cannotTargetUsingAssault: cannotEffect('targetUsingAssault'),
-    cannotTargetUsingStealth: cannotEffect('targetUsingStealth'),
+    cannotTargetUsingAssault: cannotEffect('assault'),
+    cannotTargetUsingStealth: cannotEffect('stealth'),
     setMaxGoldGain: function(max) {
         return {
             targetType: 'player',

--- a/server/game/gamesteps/ChallengeKeywordsWindow.js
+++ b/server/game/gamesteps/ChallengeKeywordsWindow.js
@@ -1,0 +1,66 @@
+const { sortBy } = require('underscore');
+const BaseStep = require('./basestep');
+
+class ChallengeKeywordsWindow extends BaseStep {
+    constructor(game, challenge) {
+        super(game);
+        this.challenge = challenge;
+        this.resolvedAbilities = [];
+    }
+
+    resolveAbility(ability, participants) {
+        if(participants.length > 1) {
+            if(typeof(ability.orderBy) === 'function') {
+                this.queueAbility(ability, sortBy(participants, participant => ability.orderBy(participant.context)));
+                return;
+            } else if(ability.orderBy === 'prompt') {
+                this.promptForOrder(ability, participants);
+                return;
+            }
+        }
+
+        this.queueAbility(ability, participants);
+    }
+
+    queueAbility(ability, participants) {
+        for(let participant of participants) {
+            this.game.queueSimpleStep(() => {
+                participant.context.resolved = this.resolvedAbilities.filter(resolved => resolved.ability.title === ability.title);
+                if(!ability.canResolve(participant.context)) {
+                    return;
+                }
+
+                this.game.resolveAbility(ability, participant.context);
+                this.resolvedAbilities.push({ ability, context: participant.context });
+            });
+        }
+    }
+
+    promptForOrder(ability, participants) {
+        this.game.getPlayersInFirstPlayerOrder().forEach(player => {
+            let cards = participants.map(participant => participant.card).filter(card => card.controller === player);
+            if(cards.length > 0) {
+                this.game.promptForSelect(player, {
+                    ordered: true,
+                    mode: 'exactly',
+                    numCards: participants.length,
+                    activePromptTitle: `Select order for ${ability.title.toLowerCase()}`,
+                    cardCondition: card => cards.includes(card),
+                    onSelect: (player, selectedCards) => {
+                        let finalParticipants = selectedCards.map(card => participants.find(participant => participant.card === card));
+        
+                        this.queueAbility(ability, finalParticipants);
+        
+                        return true;
+                    },
+                    onCancel: () => {
+                        this.queueAbility(ability, participants);
+                        return true;
+                    }
+                });
+            }
+        });
+    }
+}
+
+module.exports = ChallengeKeywordsWindow;

--- a/server/game/gamesteps/InitiatingKeywordsWindow.js
+++ b/server/game/gamesteps/InitiatingKeywordsWindow.js
@@ -1,19 +1,15 @@
-const {sortBy} = require('../../Array');
-
+const ChallengeKeywordsWindow = require('./ChallengeKeywordsWindow');
 const AbilityContext = require('../AbilityContext.js');
-const BaseStep = require('./basestep.js');
 const GameKeywords = require('../gamekeywords.js');
 
 const initiatingKeywords = ['stealth', 'assault'];
 
-class InitiatingKeywordsWindow extends BaseStep {
+class InitiatingKeywordsWindow extends ChallengeKeywordsWindow {
     constructor(game, challenge) {
-        super(game);
-        this.challenge = challenge;
+        super(game, challenge);
         this.attackingCardsWithContext = challenge.declaredAttackers.map(card => {
             return { card: card, context: new AbilityContext({ player: this.challenge.attackingPlayer, game: this.game, challenge: this.challenge, source: card }) };
         });
-        this.resolvedAbilities = [];
     }
 
     continue() {
@@ -21,29 +17,12 @@ class InitiatingKeywordsWindow extends BaseStep {
             let ability = GameKeywords[keyword];
             let attackersWithKeyword = this.attackingCardsWithContext.filter(attacker => attacker.card.hasKeyword(keyword));
 
-            if(keyword === 'assault') {
-                let sorted = sortBy(attackersWithKeyword, attacker => attacker.card.getPrintedCost()).reverse();
-                this.resolveAbility(ability, sorted);
-            } else {
+            if(attackersWithKeyword.length > 0) {
                 this.resolveAbility(ability, attackersWithKeyword);
             }
         }
 
         return true;
-    }
-
-    resolveAbility(ability, participants) {
-        for(let participant of participants) {
-            this.game.queueSimpleStep(() => {
-                participant.context.resolved = this.resolvedAbilities.filter(resolved => resolved.ability.title === ability.title);
-                if(!ability.canResolve(participant.context)) {
-                    return;
-                }
-
-                this.game.resolveAbility(ability, participant.context);
-                this.resolvedAbilities.push({ ability, context: participant.context });
-            });
-        }
     }
 }
 

--- a/server/game/gamesteps/InitiatingKeywordsWindow.js
+++ b/server/game/gamesteps/InitiatingKeywordsWindow.js
@@ -1,0 +1,50 @@
+const {sortBy} = require('../../Array');
+
+const AbilityContext = require('../AbilityContext.js');
+const BaseStep = require('./basestep.js');
+const GameKeywords = require('../gamekeywords.js');
+
+const initiatingKeywords = ['stealth', 'assault'];
+
+class InitiatingKeywordsWindow extends BaseStep {
+    constructor(game, challenge) {
+        super(game);
+        this.challenge = challenge;
+        this.attackingCardsWithContext = challenge.declaredAttackers.map(card => {
+            return { card: card, context: new AbilityContext({ player: this.challenge.attackingPlayer, game: this.game, challenge: this.challenge, source: card }) };
+        });
+        this.resolvedAbilities = [];
+    }
+
+    continue() {
+        for(let keyword of initiatingKeywords) {
+            let ability = GameKeywords[keyword];
+            let attackersWithKeyword = this.attackingCardsWithContext.filter(attacker => attacker.card.hasKeyword(keyword));
+
+            if(keyword === 'assault') {
+                let sorted = sortBy(attackersWithKeyword, attacker => attacker.card.getPrintedCost()).reverse();
+                this.resolveAbility(ability, sorted);
+            } else {
+                this.resolveAbility(ability, attackersWithKeyword);
+            }
+        }
+
+        return true;
+    }
+
+    resolveAbility(ability, participants) {
+        for(let participant of participants) {
+            this.game.queueSimpleStep(() => {
+                participant.context.resolved = this.resolvedAbilities.filter(resolved => resolved.ability.title === ability.title);
+                if(!ability.canResolve(participant.context)) {
+                    return;
+                }
+
+                this.game.resolveAbility(ability, participant.context);
+                this.resolvedAbilities.push({ ability, context: participant.context });
+            })
+        }
+    }
+}
+
+module.exports = InitiatingKeywordsWindow;

--- a/server/game/gamesteps/InitiatingKeywordsWindow.js
+++ b/server/game/gamesteps/InitiatingKeywordsWindow.js
@@ -42,7 +42,7 @@ class InitiatingKeywordsWindow extends BaseStep {
 
                 this.game.resolveAbility(ability, participant.context);
                 this.resolvedAbilities.push({ ability, context: participant.context });
-            })
+            });
         }
     }
 }

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -4,6 +4,7 @@ const SimpleStep = require('../simplestep.js');
 const ChooseParticipantsPrompt = require('./ChooseParticipantsPrompt');
 const ClaimPrompt = require('./ClaimPrompt');
 const ActionWindow = require('../actionwindow.js');
+const InitiatingKeywordsWindow = require('../InitiatingKeywordsWindow.js');
 const KeywordWindow = require('../keywordwindow.js');
 const InitiateChallenge = require('../../GameActions/InitiateChallenge');
 const DeclareDefenders = require('../../GameActions/DeclareDefenders.js');
@@ -21,7 +22,7 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.preAttackersPromptForDefenders()),
             new SimpleStep(this.game, () => this.promptForAttackers()),
             new SimpleStep(this.game, () => this.recalculateEffects()),
-            new SimpleStep(this.game, () => this.promptForInitiationKeywords()),
+            () => new InitiatingKeywordsWindow(this.game, this.challenge),
             new SimpleStep(this.game, () => this.initiateChallenge()),
             new ActionWindow(this.game, 'After attackers declared', 'attackersDeclared'),
             new SimpleStep(this.game, () => this.promptForDefenders()),
@@ -102,10 +103,6 @@ class ChallengeFlow extends BaseStep {
         this.challenge.declareAttackers(attackers);
 
         return true;
-    }
-
-    promptForInitiationKeywords() {
-        InitiateChallenge.resolveKeywords({ challenge: this.challenge });
     }
 
     initiateChallenge() {

--- a/server/game/gamesteps/challenge/challengeflow.js
+++ b/server/game/gamesteps/challenge/challengeflow.js
@@ -5,7 +5,7 @@ const ChooseParticipantsPrompt = require('./ChooseParticipantsPrompt');
 const ClaimPrompt = require('./ClaimPrompt');
 const ActionWindow = require('../actionwindow.js');
 const InitiatingKeywordsWindow = require('../InitiatingKeywordsWindow.js');
-const KeywordWindow = require('../keywordwindow.js');
+const ResolutionKeywordsWindow = require('../ResolutionKeywordsWindow.js');
 const InitiateChallenge = require('../../GameActions/InitiateChallenge');
 const DeclareDefenders = require('../../GameActions/DeclareDefenders.js');
 
@@ -32,7 +32,7 @@ class ChallengeFlow extends BaseStep {
             new SimpleStep(this.game, () => this.determineWinner()),
             new SimpleStep(this.game, () => this.challengeBonusPower()),
             new SimpleStep(this.game, () => this.beforeClaim()),
-            () => new KeywordWindow(this.game, this.challenge),
+            () => new ResolutionKeywordsWindow(this.game, this.challenge),
             new SimpleStep(this.game, () => this.atEndOfChallenge())
         ]);
 

--- a/server/game/insightkeyword.js
+++ b/server/game/insightkeyword.js
@@ -1,8 +1,8 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const GameActions = require('./GameActions');
 const TextHelper = require('./TextHelper');
 
-class InsightKeyword extends KeywordAbility {
+class InsightKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Insight', {
             message: {

--- a/server/game/intimidatekeyword.js
+++ b/server/game/intimidatekeyword.js
@@ -1,11 +1,11 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const GameActions = require('./GameActions');
 
-class IntimidateKeyword extends KeywordAbility {
+class IntimidateKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Intimidate', {
             target: {
-                activePromptTitle: context => this.getIntimidatePromptTitle(context),
+                activePromptTitle: context => this.targetPromptTitle(context),
                 numCards: context => this.getTriggerAmount(context),
                 cardCondition: (card, context) => this.canIntimidate(card, context.challenge.strengthDifference, context.challenge),
                 gameAction: 'kneel'
@@ -22,11 +22,17 @@ class IntimidateKeyword extends KeywordAbility {
                 })), context);
             }
         });
+        // Order by highest printed cost (sorts by smallest values first)
+        this.orderBy = context => -context.source.getPrintedCost();
     }
 
-    getIntimidatePromptTitle(context) {
-        var numTargets = this.getTriggerAmount(context);
-        return `Select ${numTargets === 1 ? 'a character' : `up to ${numTargets} characters`} to intimidate`;
+    targetPromptTitle(context) {
+        let numTargets = this.getTriggerAmount(context);
+        return `Select ${numTargets === 1 ? 'a character' : `up to ${numTargets} characters`} to intimidate for ${context.source.name}`;
+    }
+
+    getTriggerAmount(context) {
+        return super.getTriggerAmount(context) - context.resolved.reduce((total, resolvedIntimidate) => total += resolvedIntimidate.context.targets.getTargets(), 0);
     }
 
     canIntimidate(card, strength, challenge) {
@@ -37,7 +43,7 @@ class IntimidateKeyword extends KeywordAbility {
             && card.getStrength() <= strength;
     }
 
-    meetsRequirements(context) {
+    meetsKeywordRequirements(context) {
         return context.source.isAttacking();
     }
 }

--- a/server/game/pillagekeyword.js
+++ b/server/game/pillagekeyword.js
@@ -1,7 +1,7 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const GameActions = require('./GameActions');
 
-class PillageKeyword extends KeywordAbility {
+class PillageKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Pillage', {
             gameAction: GameActions.discardTopCards(context => ({
@@ -13,6 +13,8 @@ class PillageKeyword extends KeywordAbility {
                 event.source.game.addMessage('{0} discards {1} from the top of their deck due to Pillage on {2}', event.player, event.topCards, event.source);
             })
         });
+
+        this.orderBy = 'prompt';
     }
 }
 

--- a/server/game/renownkeyword.js
+++ b/server/game/renownkeyword.js
@@ -1,7 +1,7 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const GameActions = require('./GameActions');
 
-class RenownKeyword extends KeywordAbility {
+class RenownKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Renown', {
             message: {

--- a/server/game/stealthkeyword.js
+++ b/server/game/stealthkeyword.js
@@ -1,7 +1,7 @@
-const KeywordAbility = require('./KeywordAbility.js');
+const ChallengeKeywordAbility = require('./ChallengeKeywordAbility.js');
 const BypassByStealth = require('./GameActions/BypassByStealth.js');
 
-class StealthKeyword extends KeywordAbility {
+class StealthKeyword extends ChallengeKeywordAbility {
     constructor() {
         super('Stealth', {
             target: {
@@ -22,8 +22,8 @@ class StealthKeyword extends KeywordAbility {
         });
     }
 
-    meetsRequirements(context) {
-        return context.source.isAttacking() && context.source.allowGameAction('targetUsingStealth', context);
+    meetsKeywordRequirements(context) {
+        return context.source.isAttacking();
     }
 }
 

--- a/test/server/cards/24-TSoW/KingRobbsBannermen.spec.js
+++ b/test/server/cards/24-TSoW/KingRobbsBannermen.spec.js
@@ -1,0 +1,149 @@
+describe('King Robb\'s Bannermen', function() {
+    integration(function() {
+        beforeEach(function() {
+            const deck1 = this.buildDeck('stark', [
+                'Trading with the Pentoshi',
+                'King Robb\'s Bannermen', 'Robb Stark (AtSK)', 'Brynden\'s Outriders', 'The Horn of Winter'
+            ]);
+            const deck2 = this.buildDeck('targaryen', [
+                'Trading with the Pentoshi',
+                'The Wall (TMoW)', 'House of the Undying', 'The Great Pyramid', 'The Roseroad'
+            ]);
+            this.player1.selectDeck(deck1);
+            this.player2.selectDeck(deck2);
+            this.startGame();
+            this.keepStartingHands();
+
+            this.bannermen = this.player1.findCardByName('King Robb\'s Bannermen');
+            this.robb = this.player1.findCardByName('Robb Stark (AtSK)');
+            this.outriders = this.player1.findCardByName('Brynden\'s Outriders');
+            this.horn = this.player1.findCardByName('The Horn of Winter');
+            this.wall = this.player2.findCardByName('The Wall (TMoW)');
+            this.undying = this.player2.findCardByName('House of the Undying');
+            this.pyramid = this.player2.findCardByName('The Great Pyramid');
+            this.roseroad = this.player2.findCardByName('The Roseroad');
+
+            this.player1.clickCard(this.bannermen);
+            this.player1.clickCard(this.outriders);
+            this.player2.clickCard(this.wall);
+            this.player2.clickCard(this.roseroad);
+
+            this.completeSetup();
+
+            this.selectFirstPlayer(this.player1);
+            this.selectPlotOrder(this.player1);
+
+            this.player1.clickCard(this.robb);
+            this.player1.clickCard(this.horn);
+            this.player1.clickCard(this.robb);
+            this.player1.clickPrompt('Done');
+            this.player2.clickCard(this.undying);
+            this.player2.clickCard(this.pyramid);
+            this.player2.clickPrompt('Done');
+        });
+
+        describe('when King Robb\'s Bannermen attacks alone', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.bannermen);
+                this.player1.clickPrompt('Done');
+            });
+            it('should ask for up to 2 assault targets for King Robb\'s Bannermen', function() {
+                expect(this.player1).toHavePrompt('Select up to 2 assault targets for King Robb\'s Bannermen');
+            });
+            it('should allow you to target locations with printed cost 5 or lower for assault', function() {
+                expect(this.player1).toAllowSelect(this.pyramid);
+                expect(this.player1).toAllowSelect(this.roseroad);
+                expect(this.player1).not.toAllowSelect(this.wall);
+                expect(this.player1).not.toAllowSelect(this.undying);
+            });
+            it('should allow you to target two locations for assault', function() {
+                this.player1.clickCard(this.pyramid);
+                expect(this.player1).toAllowSelect(this.roseroad);
+                expect(this.player1).not.toAllowSelect(this.wall);
+                expect(this.player1).not.toAllowSelect(this.undying);
+            });
+        });
+
+        describe('when King Robb\'s Bannermen attacks along with a higher printed cost assault character', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.bannermen);
+                this.player1.clickCard(this.robb);
+                this.player1.clickPrompt('Done');
+            });
+            it('should ask for a single assault target for the higher cost character first', function() {
+                expect(this.player1).toHavePrompt('Select assault target for Robb Stark');
+            });
+            it('should ask for a single assault target for King Robb\'s Bannermen second', function() {
+                this.player1.clickCard(this.wall);
+                expect(this.player1).toHavePrompt('Select assault target for King Robb\'s Bannermen');
+            });
+            it('should allow you to target two locations for assault after first character targets none', function() {
+                this.player1.clickPrompt('Done');
+                this.player1.clickCard(this.pyramid);
+                expect(this.player1).toAllowSelect(this.roseroad);
+                expect(this.player1).not.toAllowSelect(this.wall);
+                expect(this.player1).not.toAllowSelect(this.undying);
+            });
+            it('should allow you to only target one location for assault after first character targets one', function() {
+                this.player1.clickCard(this.wall);
+                this.player1.clickCard(this.pyramid);
+                expect(this.player1).not.toAllowSelect(this.roseroad);
+                expect(this.player1).not.toAllowSelect(this.wall);
+                expect(this.player1).not.toAllowSelect(this.undying);
+            });
+        });
+
+        describe('when King Robb\'s Bannermen attacks along with a lower printed cost assault character', function() {
+            beforeEach(function() {
+                this.player1.clickPrompt('Military');
+                this.player1.clickCard(this.bannermen);
+                this.player1.clickCard(this.outriders);
+                this.player1.clickPrompt('Done');
+            });
+            it('should ask for up to 2 assault targets for King Robb\'s Bannermen first', function() {
+                expect(this.player1).toHavePrompt('Select up to 2 assault targets for King Robb\'s Bannermen');
+            });
+
+            describe('and you select two assault targets', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.pyramid);
+                    this.player1.clickCard(this.roseroad);
+                    this.player1.clickPrompt('Done');
+                });
+                
+                it('should not ask for the lower printed cost assault target', function() {
+                    expect(this.player1).not.toHavePrompt('Select assault target for Brynden\'s Outriders');
+                });
+            });
+
+            describe('and you select one assault target', function() {
+                beforeEach(function() {
+                    this.player1.clickCard(this.pyramid);
+                    this.player1.clickPrompt('Done');
+                });
+                
+                it('should ask for a single assault target for the lower cost character second', function() {
+                    expect(this.player1).toHavePrompt('Select assault target for Brynden\'s Outriders');
+                    expect(this.player1).toAllowSelect(this.roseroad);
+                    expect(this.player1).not.toAllowSelect(this.wall);
+                    expect(this.player1).not.toAllowSelect(this.undying);
+                });
+            });
+
+            describe('and you select no assault targets', function() {
+                beforeEach(function() {
+                    this.player1.clickPrompt('Done');
+                });
+                
+                it('should ask for a single assault target for the lower cost character second', function() {
+                    expect(this.player1).toHavePrompt('Select assault target for Brynden\'s Outriders');
+                    expect(this.player1).toAllowSelect(this.roseroad);
+                    expect(this.player1).not.toAllowSelect(this.wall);
+                    expect(this.player1).not.toAllowSelect(this.undying);
+                });
+            });
+        });
+    });
+});

--- a/test/server/integration/intimidate.spec.js
+++ b/test/server/integration/intimidate.spec.js
@@ -52,7 +52,7 @@ describe('intimidate', function() {
             });
 
             it('should prompt to kneel characters', function() {
-                expect(this.player1).toHavePrompt('Select a character to intimidate');
+                expect(this.player1).toHavePrompt('Select a character to intimidate for Robert Baratheon');
             });
 
             it('should allow a character with strengt up to the winning strength difference to be knelt', function() {
@@ -88,12 +88,12 @@ describe('intimidate', function() {
             });
 
             it('should prompt only once', function() {
-                expect(this.player1).toHavePrompt('Select a character to intimidate');
+                expect(this.player1).toHavePrompt('Select a character to intimidate for Robert Baratheon');
 
                 this.player1.clickCard(this.gendry);
                 expect(this.gendry.kneeled).toBe(true);
 
-                expect(this.player1).not.toHavePrompt('Select a character to intimidate');
+                expect(this.player1).not.toHavePrompt('Select a character to intimidate for Grey Wind');
                 expect(this.player1).not.toHavePrompt('Choose and kneel a character with 10 strength or less');
             });
         });


### PR DESCRIPTION
King Robb's Bannermen "additional targets" ruling
---
There has been an updated ruling for King Robb's Bannermen, and more specifically for "additional assault targets".

When a character can target an additional location using assault, it should raise the total number of assault targets by that 1, less the number of targets already assaulted prior to it.


### Examples
*Note that assault will always make you choose the highest-cost assaulters first*
**Example 1:**
We have Character A, who is a 7 cost with assault, and we have King Robb's Bannermen (KRB) as a 6 cost assault who can target an additional location using assault. Both are initiated into a challenge together:
- If Character A targets no locations using assault, KRB can target up to 2.
- If Character A targets 1 location using assault, KRB can target up to 1.

**Example 2:**
Going the opposite direction to Example 1, we have Character B as a 3 cost with assault, and we have King Robb's Bannermen (KRB) as a 6 cost assault who can target an additional location using assault. Both are initiated into a challenge together:
- If KRB targets no locations using assault, Character B can target up to 1.
- If KRB targets 1 location using assault, Character B can target up to 1.
- If KRB targets 2 locations using assault, Character B cannot target any.

---

These coding changes attempt to reflect this behaviour in the most generic way possible, as to help it become adaptable in other scenarios, such as if the same logic was applied to Intimidate, or if there were more characters introduced who could target additional locations using assault, or even target 3 or more using assault ~ this code *should* still work in those scenarios.

Other Keywords (Added 2/6/2023 GMT+11)
---
Along with the above, since now is the time for keyword updates, I've standardised how `ChallengeKeywords` are handled:
- Updated base keyword class from `KeywordAbility` to `ChallengeKeywordAbility` to better reflect the type of keywords these are for.
  - Within this class, combined & refined "meetsRequirements" checks among all (eg. commonly checks allowGameAction for that keyword name & a trigger amount > 0), and added `meetsKeywordRequirements` as more custom refinement, such as intimidate only being "on attack".
- Separated challenge keyword windows into `InitiationKeywordsWindow` and `ResolutionKeywordsWindow`, and implemented appropriately within `challengeFlow` - both classess share `ChallengeKeywordsWindow` for the baseline process which handles resolving/queuing of keyword abilities.
- Added a special handler for setting the "order by" for `ChallengeKeywordAbility`'s by either passing a *function*, or sending the user an order-by prompt (eg. pillage)

The main objective of this update was to pull "keyword-specific" logic out of the keyword windows, and into that ability class itself. Not necessarily *required*, but felt more correct if I was re-writing this anyway.